### PR TITLE
fix: support boolean values in .env

### DIFF
--- a/openadapt/config.py
+++ b/openadapt/config.py
@@ -88,6 +88,8 @@ _DEFAULTS = {
 
 def getenv_fallback(var_name):
     rval = os.getenv(var_name) or _DEFAULTS.get(var_name)
+    if type(rval) is str and rval.lower() in ("true", "false", "1", "0"):
+        rval = rval.lower() == "true" or rval == "1"
     if rval is None:
         raise ValueError(f"{var_name=} not defined")
     return rval


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! To ensure a prompt review of your changes, please provide the following information. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->
bugfix: currently boolean values are not being handled properly in `get_env_fallback`.

you can test this by setting SCRUB_ENABLED=false in .env and running `visualize`, it will still scrub. This is because all
nonempty strings are evaluated as True, so statements like `if config.SCRUB_ENABLED` will always be true.

I logged config.SCRUB_ENABLED to verify this:
```bash
2023-06-29 17:34:19.625 | WARNING  | openadapt.visualize:<module>:32 - false
2023-06-29 17:34:19.626 | WARNING  | openadapt.visualize:<module>:33 - <class 'str'>
```
**Summary**

modified `get_env_fallback` to support bools, regardless of case + allow binary representations

```py
def getenv_fallback(var_name):
    rval = os.getenv(var_name) or _DEFAULTS.get(var_name)
    if type(rval) is str and rval.lower() in ("true", "false", "1", "0"): <-------
        rval = rval.lower() == "true" or rval == "1"
    if rval is None:
        raise ValueError(f"{var_name=} not defined")
    return rval
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Try to link to an open issue. -->

**Checklist**
* [x] My code follows the style guidelines of OpenAdapt
* [x] I have perfomed a self-review of my code
* [x] If applicable, I have added tests to prove my fix is functional/effective
* [x] I have linted my code locally prior to submission
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [x] New and existing unit tests pass locally with my changes

**How can your code be run and tested?**

`echo SCRUB_ENABLED=false >> .env && poetry run visualize`

<!-- See the README.md for examples. Include test output. -->


**Other information**
<!-- Delete this subheading if no additional context is needed. -->
