### PR TITLE
feat: use autoformer to predict ActionEvents

### DIFF
--- a/openadapt/autoformer.py
+++ b/openadapt/autoformer.py
@@ -8,35 +8,7 @@ from openadapt.events import (
     get_events,
 )
 
-from typing import Iterable
-
-from gluonts.itertools import Cyclic, Cached
-from gluonts.dataset.loader import as_stacked_batches
-
-from transformers import PretrainedConfig
-from gluonts.time_feature import time_features_from_frequency_str
-
-from gluonts.dataset.field_names import FieldName
-from gluonts.transform import (
-    AddAgeFeature,
-    AddObservedValuesIndicator,
-    AddTimeFeatures,
-    AsNumpyArray,
-    Chain,
-    ExpectedNumInstanceSampler,
-    RemoveFields,
-    SelectFields,
-    SetField,
-    TestSplitSampler,
-    Transformation,
-    ValidationSplitSampler,
-    VstackFeatures,
-    RenameFields,
-)
-
-from gluonts.transform import InstanceSplitter
-from gluonts.transform.sampler import InstanceSampler
-from typing import Optional
+from torch.nn.utils.rnn import pad_sequence
 
 PROCESS_EVENTS = False
 
@@ -45,7 +17,8 @@ def event_to_number_timestamp(action_event):
     # negative number for clicks = groups of 2
     # return as list
     if action_event.name == "click":
-        return [-action_event.mouse_x, -action_event.mouse_y], [action_event.timestamp]
+        return [-action_event.mouse_x, -action_event.mouse_y], [action_event.timestamp,
+                                                                action_event.timestamp]
     elif action_event.name == "press":
         # TODO: special chars? normal can use vk
         pass
@@ -63,231 +36,89 @@ def events_to_numbers(action_events):
     return events_numbers, timestamps
 
 
-def create_transformation(freq: str, config: PretrainedConfig) -> Transformation:
-    # create a list of fields to remove later
-    remove_field_names = []
-    if config.num_static_real_features == 0:
-        remove_field_names.append(FieldName.FEAT_STATIC_REAL)
-    if config.num_dynamic_real_features == 0:
-        remove_field_names.append(FieldName.FEAT_DYNAMIC_REAL)
-    if config.num_static_categorical_features == 0:
-        remove_field_names.append(FieldName.FEAT_STATIC_CAT)
-
-    return Chain(
-        # step 1: remove static/dynamic fields if not specified
-        [RemoveFields(field_names=remove_field_names)]
-        # step 2: convert the data to NumPy (potentially not needed)
-        + (
-            [
-                AsNumpyArray(
-                    field=FieldName.FEAT_STATIC_CAT,
-                    expected_ndim=1,
-                    dtype=int,
-                )
-            ]
-            if config.num_static_categorical_features > 0
-            else []
-        )
-        + (
-            [
-                AsNumpyArray(
-                    field=FieldName.FEAT_STATIC_REAL,
-                    expected_ndim=1,
-                )
-            ]
-            if config.num_static_real_features > 0
-            else []
-        )
-        + [
-            AsNumpyArray(
-                field=FieldName.TARGET,
-                # we expect an extra dim for the multivariate case:
-                expected_ndim=1 if config.input_size == 1 else 2,
-            ),
-            # step 3: handle the NaN's by filling in the target with zero
-            # and return the mask (which is in the observed values)
-            # true for observed values, false for nan's
-            # the decoder uses this mask (no loss is incurred for unobserved values)
-            # see loss_weights inside the xxxForPrediction model
-            AddObservedValuesIndicator(
-                target_field=FieldName.TARGET,
-                output_field=FieldName.OBSERVED_VALUES,
-            ),
-            # step 4: add temporal features based on freq of the dataset
-            # these serve as positional encodings
-            AddTimeFeatures(
-                start_field=FieldName.START,
-                target_field=FieldName.TARGET,
-                output_field=FieldName.FEAT_TIME,
-                time_features=time_features_from_frequency_str(freq),
-                pred_length=config.prediction_length,
-            ),
-            # step 5: add another temporal feature (just a single number)
-            # tells the model where in the life the value of the time series is
-            # sort of running counter
-            AddAgeFeature(
-                target_field=FieldName.TARGET,
-                output_field=FieldName.FEAT_AGE,
-                pred_length=config.prediction_length,
-                log_scale=True,
-            ),
-            # step 6: vertically stack all the temporal features into the key FEAT_TIME
-            VstackFeatures(
-                output_field=FieldName.FEAT_TIME,
-                input_fields=[FieldName.FEAT_TIME, FieldName.FEAT_AGE]
-                             + (
-                                 [FieldName.FEAT_DYNAMIC_REAL]
-                                 if config.num_dynamic_real_features > 0
-                                 else []
-                             ),
-            ),
-            # step 7: rename to match HuggingFace names
-            RenameFields(
-                mapping={
-                    FieldName.FEAT_STATIC_CAT: "static_categorical_features",
-                    FieldName.FEAT_STATIC_REAL: "static_real_features",
-                    FieldName.FEAT_TIME: "time_features",
-                    FieldName.TARGET: "values",
-                    FieldName.OBSERVED_VALUES: "observed_mask",
-                }
-            ),
-        ]
-    )
-
-
-def create_instance_splitter(
-        config: PretrainedConfig,
-        mode: str,
-        train_sampler: Optional[InstanceSampler] = None,
-        validation_sampler: Optional[InstanceSampler] = None,
-) -> Transformation:
-    assert mode in ["train", "validation", "test"]
-
-    instance_sampler = {
-        "train": train_sampler
-                 or ExpectedNumInstanceSampler(
-            num_instances=1.0, min_future=config.prediction_length
-        ),
-        "validation": validation_sampler
-                      or ValidationSplitSampler(min_future=config.prediction_length),
-        "test": TestSplitSampler(),
-    }[mode]
-
-    return InstanceSplitter(
-        target_field="values",
-        is_pad_field=FieldName.IS_PAD,
-        start_field=FieldName.START,
-        forecast_start_field=FieldName.FORECAST_START,
-        instance_sampler=instance_sampler,
-        past_length=config.context_length + max(config.lags_sequence),
-        future_length=config.prediction_length,
-        time_series_fields=["time_features", "observed_mask"],
-    )
-
-
-def create_train_dataloader(
-        config: PretrainedConfig,
-        freq,
-        data,
-        batch_size: int,
-        num_batches_per_epoch: int,
-        shuffle_buffer_length: Optional[int] = None,
-        cache_data: bool = True,
-        **kwargs,
-) -> Iterable:
-    PREDICTION_INPUT_NAMES = [
-        "past_time_features",
-        "past_values",
-        "past_observed_mask",
-        "future_time_features",
-    ]
-    if config.num_static_categorical_features > 0:
-        PREDICTION_INPUT_NAMES.append("static_categorical_features")
-
-    if config.num_static_real_features > 0:
-        PREDICTION_INPUT_NAMES.append("static_real_features")
-
-    TRAINING_INPUT_NAMES = PREDICTION_INPUT_NAMES + [
-        "future_values",
-        "future_observed_mask",
-    ]
-
-    transformation = create_transformation(freq, config)
-    transformed_data = transformation.apply(data, is_train=True)
-    if cache_data:
-        transformed_data = Cached(transformed_data)
-
-    # we initialize a Training instance
-    instance_splitter = create_instance_splitter(config, "train")
-
-    # the instance splitter will sample a window of
-    # context length + lags + prediction length (from the 366 possible transformed time series)
-    # randomly from within the target time series and return an iterator.
-    stream = Cyclic(transformed_data).stream()
-    training_instances = instance_splitter.apply(stream, is_train=True)
-
-    return as_stacked_batches(
-        training_instances,
-        batch_size=batch_size,
-        shuffle_buffer_length=shuffle_buffer_length,
-        field_names=TRAINING_INPUT_NAMES,
-        output_type=torch.tensor,
-        num_batches_per_epoch=num_batches_per_epoch,
-    )
-
-
-def create_test_dataloader(
-        config,
-        freq,
-        data,
-        batch_size: int,
-        **kwargs,
-):
-    PREDICTION_INPUT_NAMES = [
-        "past_time_features",
-        "past_values",
-    ]
-
-    transformation = create_transformation(freq, config)
-    transformed_data = transformation.apply(data, is_train=False)
-
-    # we create a Test Instance splitter which will sample the very last
-    # context window seen during training only for the encoder.
-    instance_sampler = create_instance_splitter(config, "test")
-
-    # we apply the transformations in test mode
-    testing_instances = instance_sampler.apply(transformed_data, is_train=False)
-
-    return as_stacked_batches(
-        testing_instances,
-        batch_size=batch_size,
-        output_type=torch.tensor,
-        field_names=PREDICTION_INPUT_NAMES,
-    )
-
-
 if __name__ == "__main__":
     # TODO: put everything in a function
     recording = get_latest_recording()
     action_events = get_events(recording, process=PROCESS_EVENTS)
+    max_timestamp = action_events[-1].timestamp
     # TODO: maybe filter out release and then add back in later?
 
     # Prepare inputs for prediction
     events_as_numbers, timestamps = events_to_numbers(action_events)
-    print(events_as_numbers)
-    # Convert list to torch.FloatTensor
-    past_values_tensor = torch.tensor(events_as_numbers, dtype=torch.float32)
-    timestamps_tensor = torch.tensor(timestamps)
 
     # Inference
     # Load the trained model for prediction
     model = AutoformerForPrediction.from_pretrained("huggingface/autoformer-tourism-monthly")
+    config = model.config
+    config.lags_sequence.insert(1, 0)
+    config.lags_sequence.insert(1, 0)
+    config.lags_sequence.insert(1, 0)
+
+    context_length = config.context_length + max(config.lags_sequence)
+    prediction_length = config.prediction_length
+    batch_size = len(events_as_numbers) // context_length
+
+    # Convert lists to torch.FloatTensor
+    # Calculate the number of elements for the last batch
+    last_batch_elements = len(events_as_numbers) % context_length
+
+    # Split the data into full batches and last batch
+    full_batches = [torch.tensor(events_as_numbers[i:i + context_length]) for i in
+                    range(0, len(events_as_numbers) - last_batch_elements, context_length)]
+    last_batch = torch.tensor(events_as_numbers[-last_batch_elements:]) if last_batch_elements > 0 else None
+
+    # Pad the last batch with zeros to match the sequence length
+    if last_batch is not None:
+        last_batch = torch.cat([last_batch, torch.zeros(context_length - last_batch_elements)])
+
+    # Combine the full batches and the last batch into a single tensor
+    combined_past_values_tensor = pad_sequence(full_batches + [last_batch], batch_first=True)
+
+    # Print the combined tensor
+    print("Combined data shape:", combined_past_values_tensor.shape)
+
+    # Create the mask tensor
+    mask = (combined_past_values_tensor != 0).to(torch.bool)
+
+    # Calculate the number of elements for the last batch
+    last_batch_elements = len(timestamps) % context_length
+
+    # Split the timestamps into full batches and last batch
+    full_batches = [torch.tensor(timestamps[i:i + context_length]).unsqueeze(-1) for i in
+                    range(0, len(timestamps) - last_batch_elements, context_length)]
+    last_batch = torch.tensor(timestamps[-last_batch_elements:]).unsqueeze(
+        -1) if last_batch_elements > 0 else None
+
+    # Pad the last batch with zeros to match the sequence length
+    if last_batch is not None:
+        last_batch = torch.cat(
+            [last_batch, torch.zeros(context_length - last_batch_elements, 1)], dim=0)
+
+    # Combine the full batches and the last batch into a single tensor
+    combined_timestamps_tensor = pad_sequence(full_batches + [last_batch], batch_first=True)
+
+    # Print the combined tensor
+    print("Combined timestamps shape:", combined_timestamps_tensor.shape)
+
+    # Increment the maximum timestamp by 1 for each prediction step
+    future_timestamps = torch.arange(max_timestamp + 1, max_timestamp + 1 + prediction_length)
+
+    # Create future_time_features tensor by repeating and reshaping the timestamps
+    future_time_features = future_timestamps.unsqueeze(0).repeat(combined_timestamps_tensor.shape[0], 1).unsqueeze(-1)
+
+    # Expand dimensions to match the desired shape
+    future_time_features = future_time_features.expand(combined_timestamps_tensor.shape[0], prediction_length, 1)
+
+    print(future_time_features.shape)
 
     # Generate predictions
+    # import ipdb; ipdb.set_trace()
+
     outputs = model.generate(
-        past_values=past_values_tensor,
-        past_time_features=timestamps_tensor,
-        future_time_features=None
+        past_values=combined_past_values_tensor,
+        past_time_features=combined_timestamps_tensor,
+        future_time_features=future_time_features,
+        past_observed_mask=mask
     )
 
     mean_prediction = outputs.sequences.mean(dim=1)

--- a/openadapt/autoformer.py
+++ b/openadapt/autoformer.py
@@ -50,10 +50,9 @@ if __name__ == "__main__":
     # Load the trained model for prediction
     model = AutoformerForPrediction.from_pretrained("huggingface/autoformer-tourism-monthly")
     config = model.config
-    config.lags_sequence.insert(1, 0)
-    config.lags_sequence.insert(1, 0)
-    config.lags_sequence.insert(1, 0)
+    config.lags_sequence = [*range(1, 20)]
 
+    config.num_time_features = 1
     context_length = config.context_length + max(config.lags_sequence)
     prediction_length = config.prediction_length
     batch_size = len(events_as_numbers) // context_length
@@ -107,9 +106,9 @@ if __name__ == "__main__":
     future_time_features = future_timestamps.unsqueeze(0).repeat(combined_timestamps_tensor.shape[0], 1).unsqueeze(-1)
 
     # Expand dimensions to match the desired shape
-    future_time_features = future_time_features.expand(combined_timestamps_tensor.shape[0], prediction_length, 1)
+    future_time_features_tensor = future_time_features.expand(combined_timestamps_tensor.shape[0], prediction_length, 1)
 
-    print(future_time_features.shape)
+    print(future_time_features_tensor.shape)
 
     # Generate predictions
     # import ipdb; ipdb.set_trace()
@@ -117,7 +116,7 @@ if __name__ == "__main__":
     outputs = model.generate(
         past_values=combined_past_values_tensor,
         past_time_features=combined_timestamps_tensor,
-        future_time_features=future_time_features,
+        future_time_features=future_time_features_tensor,
         past_observed_mask=mask
     )
 
@@ -125,5 +124,6 @@ if __name__ == "__main__":
 
     # Use the mean prediction for further analysis or tasks
     print(mean_prediction)
+    print(mean_prediction.shape)
 
     # TODO: turn into ActionEvents

--- a/openadapt/autoformer.py
+++ b/openadapt/autoformer.py
@@ -1,0 +1,298 @@
+from transformers import AutoformerForPrediction
+import torch
+
+from openadapt.crud import (
+    get_latest_recording,
+)
+from openadapt.events import (
+    get_events,
+)
+
+from typing import Iterable
+
+from gluonts.itertools import Cyclic, Cached
+from gluonts.dataset.loader import as_stacked_batches
+
+from transformers import PretrainedConfig
+from gluonts.time_feature import time_features_from_frequency_str
+
+from gluonts.dataset.field_names import FieldName
+from gluonts.transform import (
+    AddAgeFeature,
+    AddObservedValuesIndicator,
+    AddTimeFeatures,
+    AsNumpyArray,
+    Chain,
+    ExpectedNumInstanceSampler,
+    RemoveFields,
+    SelectFields,
+    SetField,
+    TestSplitSampler,
+    Transformation,
+    ValidationSplitSampler,
+    VstackFeatures,
+    RenameFields,
+)
+
+from gluonts.transform import InstanceSplitter
+from gluonts.transform.sampler import InstanceSampler
+from typing import Optional
+
+PROCESS_EVENTS = False
+
+
+def event_to_number_timestamp(action_event):
+    # negative number for clicks = groups of 2
+    # return as list
+    if action_event.name == "click":
+        return [-action_event.mouse_x, -action_event.mouse_y], [action_event.timestamp]
+    elif action_event.name == "press":
+        # TODO: special chars? normal can use vk
+        pass
+    return [], []
+
+
+def events_to_numbers(action_events):
+    events_numbers = []
+    timestamps = []
+    for action_event in action_events:
+        nums, timestamp = event_to_number_timestamp(action_event)
+        events_numbers.extend(nums)
+        timestamps.extend(timestamp)
+
+    return events_numbers, timestamps
+
+
+def create_transformation(freq: str, config: PretrainedConfig) -> Transformation:
+    # create a list of fields to remove later
+    remove_field_names = []
+    if config.num_static_real_features == 0:
+        remove_field_names.append(FieldName.FEAT_STATIC_REAL)
+    if config.num_dynamic_real_features == 0:
+        remove_field_names.append(FieldName.FEAT_DYNAMIC_REAL)
+    if config.num_static_categorical_features == 0:
+        remove_field_names.append(FieldName.FEAT_STATIC_CAT)
+
+    return Chain(
+        # step 1: remove static/dynamic fields if not specified
+        [RemoveFields(field_names=remove_field_names)]
+        # step 2: convert the data to NumPy (potentially not needed)
+        + (
+            [
+                AsNumpyArray(
+                    field=FieldName.FEAT_STATIC_CAT,
+                    expected_ndim=1,
+                    dtype=int,
+                )
+            ]
+            if config.num_static_categorical_features > 0
+            else []
+        )
+        + (
+            [
+                AsNumpyArray(
+                    field=FieldName.FEAT_STATIC_REAL,
+                    expected_ndim=1,
+                )
+            ]
+            if config.num_static_real_features > 0
+            else []
+        )
+        + [
+            AsNumpyArray(
+                field=FieldName.TARGET,
+                # we expect an extra dim for the multivariate case:
+                expected_ndim=1 if config.input_size == 1 else 2,
+            ),
+            # step 3: handle the NaN's by filling in the target with zero
+            # and return the mask (which is in the observed values)
+            # true for observed values, false for nan's
+            # the decoder uses this mask (no loss is incurred for unobserved values)
+            # see loss_weights inside the xxxForPrediction model
+            AddObservedValuesIndicator(
+                target_field=FieldName.TARGET,
+                output_field=FieldName.OBSERVED_VALUES,
+            ),
+            # step 4: add temporal features based on freq of the dataset
+            # these serve as positional encodings
+            AddTimeFeatures(
+                start_field=FieldName.START,
+                target_field=FieldName.TARGET,
+                output_field=FieldName.FEAT_TIME,
+                time_features=time_features_from_frequency_str(freq),
+                pred_length=config.prediction_length,
+            ),
+            # step 5: add another temporal feature (just a single number)
+            # tells the model where in the life the value of the time series is
+            # sort of running counter
+            AddAgeFeature(
+                target_field=FieldName.TARGET,
+                output_field=FieldName.FEAT_AGE,
+                pred_length=config.prediction_length,
+                log_scale=True,
+            ),
+            # step 6: vertically stack all the temporal features into the key FEAT_TIME
+            VstackFeatures(
+                output_field=FieldName.FEAT_TIME,
+                input_fields=[FieldName.FEAT_TIME, FieldName.FEAT_AGE]
+                             + (
+                                 [FieldName.FEAT_DYNAMIC_REAL]
+                                 if config.num_dynamic_real_features > 0
+                                 else []
+                             ),
+            ),
+            # step 7: rename to match HuggingFace names
+            RenameFields(
+                mapping={
+                    FieldName.FEAT_STATIC_CAT: "static_categorical_features",
+                    FieldName.FEAT_STATIC_REAL: "static_real_features",
+                    FieldName.FEAT_TIME: "time_features",
+                    FieldName.TARGET: "values",
+                    FieldName.OBSERVED_VALUES: "observed_mask",
+                }
+            ),
+        ]
+    )
+
+
+def create_instance_splitter(
+        config: PretrainedConfig,
+        mode: str,
+        train_sampler: Optional[InstanceSampler] = None,
+        validation_sampler: Optional[InstanceSampler] = None,
+) -> Transformation:
+    assert mode in ["train", "validation", "test"]
+
+    instance_sampler = {
+        "train": train_sampler
+                 or ExpectedNumInstanceSampler(
+            num_instances=1.0, min_future=config.prediction_length
+        ),
+        "validation": validation_sampler
+                      or ValidationSplitSampler(min_future=config.prediction_length),
+        "test": TestSplitSampler(),
+    }[mode]
+
+    return InstanceSplitter(
+        target_field="values",
+        is_pad_field=FieldName.IS_PAD,
+        start_field=FieldName.START,
+        forecast_start_field=FieldName.FORECAST_START,
+        instance_sampler=instance_sampler,
+        past_length=config.context_length + max(config.lags_sequence),
+        future_length=config.prediction_length,
+        time_series_fields=["time_features", "observed_mask"],
+    )
+
+
+def create_train_dataloader(
+        config: PretrainedConfig,
+        freq,
+        data,
+        batch_size: int,
+        num_batches_per_epoch: int,
+        shuffle_buffer_length: Optional[int] = None,
+        cache_data: bool = True,
+        **kwargs,
+) -> Iterable:
+    PREDICTION_INPUT_NAMES = [
+        "past_time_features",
+        "past_values",
+        "past_observed_mask",
+        "future_time_features",
+    ]
+    if config.num_static_categorical_features > 0:
+        PREDICTION_INPUT_NAMES.append("static_categorical_features")
+
+    if config.num_static_real_features > 0:
+        PREDICTION_INPUT_NAMES.append("static_real_features")
+
+    TRAINING_INPUT_NAMES = PREDICTION_INPUT_NAMES + [
+        "future_values",
+        "future_observed_mask",
+    ]
+
+    transformation = create_transformation(freq, config)
+    transformed_data = transformation.apply(data, is_train=True)
+    if cache_data:
+        transformed_data = Cached(transformed_data)
+
+    # we initialize a Training instance
+    instance_splitter = create_instance_splitter(config, "train")
+
+    # the instance splitter will sample a window of
+    # context length + lags + prediction length (from the 366 possible transformed time series)
+    # randomly from within the target time series and return an iterator.
+    stream = Cyclic(transformed_data).stream()
+    training_instances = instance_splitter.apply(stream, is_train=True)
+
+    return as_stacked_batches(
+        training_instances,
+        batch_size=batch_size,
+        shuffle_buffer_length=shuffle_buffer_length,
+        field_names=TRAINING_INPUT_NAMES,
+        output_type=torch.tensor,
+        num_batches_per_epoch=num_batches_per_epoch,
+    )
+
+
+def create_test_dataloader(
+        config,
+        freq,
+        data,
+        batch_size: int,
+        **kwargs,
+):
+    PREDICTION_INPUT_NAMES = [
+        "past_time_features",
+        "past_values",
+    ]
+
+    transformation = create_transformation(freq, config)
+    transformed_data = transformation.apply(data, is_train=False)
+
+    # we create a Test Instance splitter which will sample the very last
+    # context window seen during training only for the encoder.
+    instance_sampler = create_instance_splitter(config, "test")
+
+    # we apply the transformations in test mode
+    testing_instances = instance_sampler.apply(transformed_data, is_train=False)
+
+    return as_stacked_batches(
+        testing_instances,
+        batch_size=batch_size,
+        output_type=torch.tensor,
+        field_names=PREDICTION_INPUT_NAMES,
+    )
+
+
+if __name__ == "__main__":
+    # TODO: put everything in a function
+    recording = get_latest_recording()
+    action_events = get_events(recording, process=PROCESS_EVENTS)
+    # TODO: maybe filter out release and then add back in later?
+
+    # Prepare inputs for prediction
+    events_as_numbers, timestamps = events_to_numbers(action_events)
+    print(events_as_numbers)
+    # Convert list to torch.FloatTensor
+    past_values_tensor = torch.tensor(events_as_numbers, dtype=torch.float32)
+    timestamps_tensor = torch.tensor(timestamps)
+
+    # Inference
+    # Load the trained model for prediction
+    model = AutoformerForPrediction.from_pretrained("huggingface/autoformer-tourism-monthly")
+
+    # Generate predictions
+    outputs = model.generate(
+        past_values=past_values_tensor,
+        past_time_features=timestamps_tensor,
+        future_time_features=None
+    )
+
+    mean_prediction = outputs.sequences.mean(dim=1)
+
+    # Use the mean prediction for further analysis or tasks
+    print(mean_prediction)
+
+    # TODO: turn into ActionEvents

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,6 @@ tiktoken==0.4.0
 torch==2.0.0
 tqdm==4.64.0
 nicegui==1.2.16
-transformers==4.29.2
+transformers==4.30.0
 python-dotenv==1.0.0
 python-Levenshtein==0.21.1


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! To ensure a prompt review of your changes, please provide the following information. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->
This PR attempts to use the [Autoformer model](https://huggingface.co/docs/transformers/main/en/model_doc/autoformer#transformers.AutoformerForPrediction.forward.future_time_features) to predict future ActionEvents given a time series of past ActionEvents (converted to real numbers). The goal is to be able to get the ActionEvents from the latest recording, convert them to real numbers, and feed them to the model, then get back its prediction and convert the numbers back to ActionEvents. Related to [issue #287](https://github.com/OpenAdaptAI/OpenAdapt/issues/287).

**Checklist**
* [ ] My code follows the style guidelines of OpenAdapt
* [ ] I have performed a self-review of my code
* [ ] If applicable, I have added tests to prove my fix is functional/effective
* [ ] I have linted my code locally prior to submission
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [ ] New and existing unit tests pass locally with my changes

**How can your code be run and tested?**

<!-- See the README.md for examples. Include test output. -->
