### PR TITLE
fix: loguru exception handling for invalid recordings

### DIFF
--- a/openadapt/crud.py
+++ b/openadapt/crud.py
@@ -1,3 +1,4 @@
+import sys
 from loguru import logger
 import sqlalchemy as sa
 
@@ -155,7 +156,10 @@ def _get(table, recording_timestamp):
     )
 
 
+@logger.catch(reraise=True, onerror=lambda _: sys.exit(1))
 def get_action_events(recording):
+    if recording is None:
+        raise ValueError("Invalid recording")
     action_events = _get(ActionEvent, recording.timestamp)
     # filter out stop sequences listed in STOP_SEQUENCES and Ctrl + C
     filter_stop_sequences(action_events)
@@ -232,7 +236,7 @@ def get_screenshots(recording, precompute_diffs=False):
 
     # TODO: store diffs
     if precompute_diffs:
-        logger.info(f"precomputing diffs...")
+        logger.info("precomputing diffs...")
         [(screenshot.diff, screenshot.diff_mask) for screenshot in screenshots]
 
     return screenshots

--- a/openadapt/crud.py
+++ b/openadapt/crud.py
@@ -159,7 +159,7 @@ def _get(table, recording_timestamp):
 @logger.catch(reraise=True, onerror=lambda _: sys.exit(1))
 def get_action_events(recording):
     if recording is None:
-        raise ValueError("Invalid recording")
+        raise ValueError("Invalid recording.")
     action_events = _get(ActionEvent, recording.timestamp)
     # filter out stop sequences listed in STOP_SEQUENCES and Ctrl + C
     filter_stop_sequences(action_events)

--- a/openadapt/crud.py
+++ b/openadapt/crud.py
@@ -158,8 +158,7 @@ def _get(table, recording_timestamp):
 
 @logger.catch(reraise=True, onerror=lambda _: sys.exit(1))
 def get_action_events(recording):
-    if recording is None:
-        raise ValueError("Invalid recording.")
+    assert recording, "Invalid recording."
     action_events = _get(ActionEvent, recording.timestamp)
     # filter out stop sequences listed in STOP_SEQUENCES and Ctrl + C
     filter_stop_sequences(action_events)

--- a/openadapt/crud.py
+++ b/openadapt/crud.py
@@ -1,4 +1,3 @@
-import sys
 from loguru import logger
 import sqlalchemy as sa
 

--- a/openadapt/crud.py
+++ b/openadapt/crud.py
@@ -227,7 +227,8 @@ def get_screenshots(recording, precompute_diffs=False):
 
     for prev, cur in zip(screenshots, screenshots[1:]):
         cur.prev = prev
-    screenshots[0].prev = screenshots[0]
+    if screenshots:
+        screenshots[0].prev = screenshots[0]
 
     # TODO: store diffs
     if precompute_diffs:

--- a/openadapt/crud.py
+++ b/openadapt/crud.py
@@ -156,7 +156,6 @@ def _get(table, recording_timestamp):
     )
 
 
-@logger.catch(reraise=True, onerror=lambda _: sys.exit(1))
 def get_action_events(recording):
     assert recording, "Invalid recording."
     action_events = _get(ActionEvent, recording.timestamp)

--- a/openadapt/events.py
+++ b/openadapt/events.py
@@ -1,4 +1,3 @@
-import sys
 import time
 
 from loguru import logger

--- a/openadapt/events.py
+++ b/openadapt/events.py
@@ -25,6 +25,8 @@ def get_events(
     logger.debug(f"raw_action_event_dicts=\n{pformat(raw_action_event_dicts)}")
 
     num_action_events = len(action_events)
+    if num_action_events == 0:
+        raise ValueError("No action events found.")
     num_window_events = len(window_events)
     num_screenshots = len(screenshots)
 

--- a/openadapt/events.py
+++ b/openadapt/events.py
@@ -12,7 +12,6 @@ from openadapt import common, config, crud, models, utils
 MAX_PROCESS_ITERS = 1
 
 
-@logger.catch(reraise=True, onerror=lambda _: sys.exit(1))
 def get_events(
     recording,
     process=True,

--- a/openadapt/events.py
+++ b/openadapt/events.py
@@ -27,8 +27,7 @@ def get_events(
     logger.debug(f"raw_action_event_dicts=\n{pformat(raw_action_event_dicts)}")
 
     num_action_events = len(action_events)
-    if num_action_events == 0:
-        raise ValueError("No action events found.")
+    assert num_action_events > 0, "No action events found."
     num_window_events = len(window_events)
     num_screenshots = len(screenshots)
 

--- a/openadapt/events.py
+++ b/openadapt/events.py
@@ -1,3 +1,4 @@
+import sys
 import time
 
 from loguru import logger
@@ -11,6 +12,7 @@ from openadapt import common, config, crud, models, utils
 MAX_PROCESS_ITERS = 1
 
 
+@logger.catch(reraise=True, onerror=lambda _: sys.exit(1))
 def get_events(
     recording,
     process=True,

--- a/openadapt/record.py
+++ b/openadapt/record.py
@@ -677,7 +677,7 @@ def read_mouse_events(
     terminate_event.wait()
     mouse_listener.stop()
 
-
+@logger.catch
 @trace(logger)
 def record(
     task_description: str,

--- a/openadapt/replay.py
+++ b/openadapt/replay.py
@@ -10,7 +10,7 @@ from openadapt import crud, utils
 
 LOG_LEVEL = "INFO"
 
-
+@logger.catch()
 def replay(
     strategy_name: str,
     timestamp: Union[str, None] = None,

--- a/openadapt/replay.py
+++ b/openadapt/replay.py
@@ -10,7 +10,7 @@ from openadapt import crud, utils
 
 LOG_LEVEL = "INFO"
 
-@logger.catch()
+@logger.catch
 def replay(
     strategy_name: str,
     timestamp: Union[str, None] = None,

--- a/openadapt/visualize.py
+++ b/openadapt/visualize.py
@@ -149,7 +149,7 @@ def dict2html(obj, max_children=MAX_TABLE_CHILDREN, max_len=MAX_TABLE_STR_LEN):
             html_str = head + middle + tail
     return html_str
 
-@logger.catch()
+@logger.catch
 def main():
     configure_logging(logger, LOG_LEVEL)
 

--- a/openadapt/visualize.py
+++ b/openadapt/visualize.py
@@ -149,7 +149,7 @@ def dict2html(obj, max_children=MAX_TABLE_CHILDREN, max_len=MAX_TABLE_STR_LEN):
             html_str = head + middle + tail
     return html_str
 
-
+@logger.catch()
 def main():
     configure_logging(logger, LOG_LEVEL)
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! To ensure a prompt review of your changes, please provide the following information. -->

**What kind of change does this PR introduce?**

raises errors for invalid recordings
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Try to link to an open issue. -->
when attempting to visualize with a broken recording (not written properly if interrupted early), you may get a message like:
```
  File "/Users/aaron/Documents/GitHub/OpenAdapt/openadapt/app/tray.py", line 108, in _visualize
    visualize(recording)
  File "/Users/aaron/Documents/GitHub/OpenAdapt/openadapt/visualize.py", line 163, in main
    action_events = get_events(recording, process=PROCESS_EVENTS, meta=meta)
  File "/Users/aaron/Documents/GitHub/OpenAdapt/openadapt/events.py", line 22, in get_events
    screenshots = crud.get_screenshots(recording)
  File "/Users/aaron/Documents/GitHub/OpenAdapt/openadapt/crud.py", line 240, in get_screenshots
    screenshots[0].prev = screenshots[0]
IndexError: list index out of range
```
or 
```
  File "/Users/aaron/Documents/GitHub/OpenAdapt/openadapt/visualize.py", line 163, in main
    action_events = get_events(recording, process=PROCESS_EVENTS, meta=meta)
  File "/Users/aaron/Documents/GitHub/OpenAdapt/openadapt/events.py", line 46, in get_events
    action_events, window_events, screenshots = process_events(
  File "/Users/aaron/Documents/GitHub/OpenAdapt/openadapt/events.py", line 633, in process_events
    pct_action_events = num_action_events_ / num_action_events
ZeroDivisionError: division by zero
```

now, we get messages like:
```
2023-07-07 12:00:27.346 | ERROR    | openadapt.visualize:main:162 - An error has been caught in function 'main', process 'MainProcess' (5263), thread 'MainThread' (8153144128):
Traceback (most recent call last):

  File "<string>", line 1, in <module>

> File "/Users/aaron/Documents/GitHub/OpenAdapt/openadapt/visualize.py", line 162, in main
    action_events = get_events(recording, process=PROCESS_EVENTS, meta=meta)
                    |          |                  |                    -> {}
                    |          |                  -> True
                    |          -> Recording(id=1, timestamp=1688745592.017052, monitor_width=1440, monitor_height=900, double_click_interval_seconds=0.5, doubl...
                    -> <function get_events at 0x16a9f7c70>

  File "/Users/aaron/Documents/GitHub/OpenAdapt/openadapt/events.py", line 30, in get_events
    raise ValueError("No action events found.")

ValueError: No action events found.
```
or 
```
2023-07-07 11:58:53.627 | ERROR    | openadapt.events:get_events:20 - An error has been caught in function 'get_events', process 'MainProcess' (4998), thread 'MainThread' (8153144128):
Traceback (most recent call last):

  File "<string>", line 1, in <module>

  File "/Users/aaron/Documents/GitHub/OpenAdapt/openadapt/visualize.py", line 162, in main
    action_events = get_events(recording, process=PROCESS_EVENTS, meta=meta)
                    |          |                  |                    -> {}
                    |          |                  -> True
                    |          -> None
                    -> <function get_events at 0x13b6dbf40>

> File "/Users/aaron/Documents/GitHub/OpenAdapt/openadapt/events.py", line 20, in get_events
    action_events = crud.get_action_events(recording)
                    |    |                 -> None
                    |    -> <function get_action_events at 0x13b6dbc70>
                    -> <module 'openadapt.crud' from '/Users/aaron/Documents/GitHub/OpenAdapt/openadapt/crud.py'>

  File "/Users/aaron/Documents/GitHub/OpenAdapt/openadapt/crud.py", line 161, in get_action_events
    raise ValueError("Invalid recording")

ValueError: Invalid recording
```

**Checklist**
* [x] My code follows the style guidelines of OpenAdapt
* [x] I have performed a self-review of my code
* [x] If applicable, I have added tests to prove my fix is functional/effective
* [x] I have linted my code locally prior to submission
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [x] New and existing unit tests pass locally with my changes

**How can your code be run and tested?**

<!-- See the README.md for examples. Include test output. -->


**Other information**
<!-- Delete this subheading if no additional context is needed. -->
