### PR TITLE
fix(utils): prevent duplicate log messages (#339) 

### DIFF
--- a/openadapt/record.py
+++ b/openadapt/record.py
@@ -134,7 +134,6 @@ def process_events(
         terminate_event: An event to signal the termination of the process.
     """
 
-    utils.configure_logging(logger, LOG_LEVEL)
     utils.set_start_time(recording_timestamp)
     logger.info(f"starting")
 
@@ -278,7 +277,6 @@ def write_events(
             the number of events left to be written.
     """
 
-    utils.configure_logging(logger, LOG_LEVEL)
     utils.set_start_time(recording_timestamp)
     logger.info(f"{event_type=} starting")
     signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -436,7 +434,6 @@ def read_screen_events(
         recording_timestamp: The timestamp of the recording.
     """
 
-    utils.configure_logging(logger, LOG_LEVEL)
     utils.set_start_time(recording_timestamp)
     logger.info(f"starting")
     while not terminate_event.is_set():
@@ -463,7 +460,6 @@ def read_window_events(
         recording_timestamp: The timestamp of the recording.
     """
 
-    utils.configure_logging(logger, LOG_LEVEL)
     utils.set_start_time(recording_timestamp)
     logger.info(f"starting")
     prev_window_data = {}
@@ -513,7 +509,6 @@ def performance_stats_writer(
         terminate_event: An event to signal the termination of the process.
     """
 
-    utils.configure_logging(logger, LOG_LEVEL)
     utils.set_start_time(recording_timestamp)
     logger.info("performance stats writer starting")
     signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -535,7 +530,6 @@ def performance_stats_writer(
 def memory_writer(
     recording_timestamp: float, terminate_event: multiprocessing.Event, record_pid: int
 ):
-    utils.configure_logging(logger, LOG_LEVEL)
     utils.set_start_time(recording_timestamp)
     logger.info("Memory writer starting")
     signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -689,7 +683,6 @@ def record(
         task_description: a text description of the task that will be recorded
     """
 
-    utils.configure_logging(logger, LOG_LEVEL)
     logger.info(f"{task_description=}")
 
     recording = create_recording(task_description)

--- a/openadapt/utils.py
+++ b/openadapt/utils.py
@@ -32,10 +32,10 @@ def configure_logging(logger, log_level):
     with _logger_lock:
         logger.remove()
         logger_format = (
-            "{time:YYYY-MM-DD HH:mm:ss.SSS} | "
-            "{level: <8} | "
-            "{name}:{function}:{line} "
-            "- {message}"
+            "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
+            "<level>{level: <8}</level> | "
+            "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> "
+            "- <level>{message}</level>"
         )
         logger.add(
             StreamHandler(sys.stderr),

--- a/openadapt/utils.py
+++ b/openadapt/utils.py
@@ -6,6 +6,7 @@ import fire
 import inspect
 import os
 import sys
+import threading
 import time
 
 from loguru import logger
@@ -20,27 +21,31 @@ from openadapt import common, config
 
 EMPTY = (None, [], {}, "")
 
+_logger_lock = threading.Lock()
+
 
 def configure_logging(logger, log_level):
     # TODO: redact log messages (https://github.com/Delgan/loguru/issues/17#issuecomment-717526130)
     log_level_override = os.getenv("LOG_LEVEL")
     log_level = log_level_override or log_level
-    logger.remove()
-    logger_format = (
-        "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
-        "<level>{level: <8}</level> | "
-        "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> "
-        "- <level>{message}</level>"
-    )
-    logger.add(
-        StreamHandler(sys.stderr),
-        colorize=True,
-        level=log_level,
-        enqueue=True,
-        format=logger_format,
-        filter=config.filter_log_messages if config.IGNORE_WARNINGS else None,
-    )
-    logger.debug(f"{log_level=}")
+
+    with _logger_lock:
+        logger.remove()
+        logger_format = (
+            "{time:YYYY-MM-DD HH:mm:ss.SSS} | "
+            "{level: <8} | "
+            "{name}:{function}:{line} "
+            "- {message}"
+        )
+        logger.add(
+            StreamHandler(sys.stderr),
+            colorize=True,
+            level=log_level,
+            enqueue=True,
+            format=logger_format,
+            filter=config.filter_log_messages if config.IGNORE_WARNINGS else None,
+        )
+        logger.debug(f"{log_level=}")
 
 
 def row2dict(row, follow=True):


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes a race condition in `utils.configure_logging` which leads to duplicate log messages.

**Summary**
Fixes #339.

The duplicate messages are caused by multiple threads calling `configure_logging` concurrently. This function had a race condition where two threads could both call `logger.remove()` and then both call `logger.add()`, creating two identical sinks. 

Adding a lock prevents this bug although I don't think it makes `configure_logging` entirely thread-safe. In particular, if thread A tries to log something after thread B has called `logger.remove()`, but before it calls `logger.add()`, the message might get dropped (though I haven't observed this in practice). 

I also removed some redundant `configure_logging` calls in `record.py`. This isn't necessary to fix the bug, but it seemed like a worthwhile cleanup. It's in a separate commit so it can easily be dropped if not desired.

**Checklist**
* [X] My code follows the style guidelines of OpenAdapt
* [X] I have performed a self-review of my code
* [X] If applicable, I have added tests to prove my fix is functional/effective
* [X] I have linted my code locally prior to submission
* [X] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [X] New and existing unit tests pass locally with my changes

**How can your code be run and tested?**
`python -m openadapt.record foo` will reproduce the original issue and validate the fix.

**Other information**
I saw your post on Hacker News and I might be interested in paid work on OpenAdapt. How can I learn more?