### PR TITLE
chore: add preview option to black pre-commit hook and update README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,9 @@ repos:
     rev: 23.7.0
     hooks:
     -   id: black
+        args: [--preview]
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
-        args: ["--profile", "black"]

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ alembic revision --autogenerate -m "<msg>"
 
 ### Pre-commit Hooks
 
-To ensure code quality and consistency, OpenAdapt uses pre-commit hooks. These hooks 
+To ensure code quality and consistency, OpenAdapt uses pre-commit hooks. These hooks
 will be executed automatically before each commit to perform various checks and
 validations on your codebase.
 
@@ -264,12 +264,13 @@ The following pre-commit hooks are used in OpenAdapt:
 - [check-yaml](https://github.com/pre-commit/pre-commit-hooks#check-yaml): Validates the syntax and structure of YAML files.
 - [end-of-file-fixer](https://github.com/pre-commit/pre-commit-hooks#end-of-file-fixer): Ensures that files end with a newline character.
 - [trailing-whitespace](https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace): Detects and removes trailing whitespace at the end of lines.
+- [black](https://github.com/psf/black): Formats Python code to adhere to the Black code style.
 - [isort](https://github.com/PyCQA/isort): Sorts Python import statements in a consistent and standardized manner.
 
 To set up the pre-commit hooks, follow these steps:
 
 1. Navigate to the root directory of your OpenAdapt repository.
- 
+
 2. Run the following command to install the hooks:
 
 ```


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! To ensure a prompt review of your changes, please provide the following information. -->

**What kind of change does this PR introduce?**

Add `--preview` flag to python black pre-commit hook, and update `README.md` on black pre-commit hook.

**Summary**

We want to use future python `black` formatting as mentioned [here](https://black.readthedocs.io/en/stable/the_black_code_style/future_style.html#labels-preview-style).

**Checklist**
* [x] My code follows the style guidelines of OpenAdapt
* [x] I have performed a self-review of my code
* [x] If applicable, I have added tests to prove my fix is functional/effective
* [x] I have linted my code locally prior to submission
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [x] New and existing unit tests pass locally with my changes

**How can your code be run and tested?**

Run `pre-commit install` to update pre-commit hooks and test when staging files that need formatting changes.