### PR TITLE
fix: pytest on Latest Merge

### DIFF
--- a/tests/openadapt/test_scrub.py
+++ b/tests/openadapt/test_scrub.py
@@ -115,7 +115,7 @@ def test_scrub_address() -> None:
     """Test that the address is scrubbed."""
     assert (
         scrub.scrub_text("My address is 123 Main St, Toronto, On, CAN.")
-        == "My address is 123 Main St, <LOCATION>, On, <LOCATION>."
+        == "My address is 123 Main St, <LOCATION>, <LOCATION>, <LOCATION>."
     )
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! To ensure a prompt review of your changes, please provide the following information. -->
Fixes failing test_scrub test due to change in presidio version
**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->
bugfix: On running pytest on Latest Openadapt


```
   def test_scrub_address() -> None:
        """Test that the address is scrubbed."""
>       assert (
            scrub.scrub_text("My address is 123 Main St, Toronto, On, CAN.")
            == "My address is 123 Main St, <LOCATION>, On, <LOCATION>."
        )
E       AssertionError: assert 'My address i..., <LOCATION>.' == 'My address i..., <LOCATION>.'
E         - My address is 123 Main St, <LOCATION>, On, <LOCATION>.
E         ?                                         ^
E         + My address is 123 Main St, <LOCATION>, <LOCATION>, <LOCATION>.
E         ?     
```
**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Try to link to an open issue. -->

**Checklist**
* [x] My code follows the style guidelines of OpenAdapt
* [x] I have performed a self-review of my code
* [x] If applicable, I have added tests to prove my fix is functional/effective
* [x] I have linted my code locally prior to submission
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [x] New and existing unit tests pass locally with my changes

**How can your code be run and tested?**

<!-- See the README.md for examples. Include test output. -->


**Other information**
<!-- Delete this subheading if no additional context is needed. -->
