### PR TITLE
fix(tests.openadapt.privacy.providers): failing `test_comprehend_scrub.py`

### DIFF
--- a/tests/openadapt/privacy/providers/test_comprehend_scrub.py
+++ b/tests/openadapt/privacy/providers/test_comprehend_scrub.py
@@ -10,10 +10,11 @@ scrub = ComprehendScrubbingProvider()
 try:
     scrub.scrub_text("hello Bob smith")
 except NoRegionError:
-    pytestmark = pytest.mark.skip(
-        reason="AWS Config Files not setup correctly. Please see "
+    msg = (
+        "AWS Config Files not setup correctly. Please see "
         "https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html#configuration"  # noqa: E501
     )
+    pytestmark = pytest.mark.skip(reason=msg)
 
 
 def _hex_to_rgb(hex_color: int) -> tuple[int, int, int]:

--- a/tests/openadapt/privacy/providers/test_comprehend_scrub.py
+++ b/tests/openadapt/privacy/providers/test_comprehend_scrub.py
@@ -1,9 +1,19 @@
 """Module to test ComprehendScrubbingProvider."""
 
+from botocore.exceptions import NoRegionError
+import pytest
 
 from openadapt.privacy.providers.aws_comprehend import ComprehendScrubbingProvider
 
 scrub = ComprehendScrubbingProvider()
+
+try:
+    scrub.scrub_text("hello Bob smith")
+except NoRegionError:
+    pytestmark = pytest.mark.skip(
+        reason="AWS Config Files not setup correctly. Please see "
+        "https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html#configuration"  # noqa: E501
+    )
 
 
 def _hex_to_rgb(hex_color: int) -> tuple[int, int, int]:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! To ensure a prompt review of your changes, please provide the following information. -->
**What kind of change does this PR introduce?**
Fixes pytest which is failing due to aws config files not found on machines.

Now, the tests in `test_comprehend_scrub.py` gets skipped if AWS Config files are not found or not correctly setup.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Try to link to an open issue. -->

**Checklist**
* [x] My code follows the style guidelines of OpenAdapt
* [x] I have performed a self-review of my code
* [x] If applicable, I have added tests to prove my fix is functional/effective
* [x] I have linted my code locally prior to submission
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [x] New and existing unit tests pass locally with my changes

**How can your code be run and tested?**

<!-- See the README.md for examples. Include test output. -->


**Other information**
<!-- Delete this subheading if no additional context is needed. -->
