### PR TITLE
fix: resolve repository not found error in mac install.sh script

### DIFF
--- a/install/install_openadapt.sh
+++ b/install/install_openadapt.sh
@@ -11,7 +11,7 @@ pythonInstallerLoc="https://www.python.org/ftp/python/3.10.11/python-3.10.11-mac
 
 # Set default values when no parameters are provided
 BRANCH=${BRANCH:-main}
-REPO=${REPO:-https://github.com/OpenAdaptAI/OpenAdapt.git}
+REPO=${REPO:-OpenAdaptAI/OpenAdapt.git}
 
 REPO_URL="https://github.com/$REPO"
 

--- a/install/install_openadapt.sh
+++ b/install/install_openadapt.sh
@@ -11,7 +11,7 @@ pythonInstallerLoc="https://www.python.org/ftp/python/3.10.11/python-3.10.11-mac
 
 # Set default values when no parameters are provided
 BRANCH=${BRANCH:-main}
-REPO=${REPO:-https://github.com/MLDSAI/OpenAdapt.git}
+REPO=${REPO:-https://github.com/OpenAdaptAI/OpenAdapt.git}
 
 REPO_URL="https://github.com/$REPO"
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! To ensure a prompt review of your changes, please provide the following information. -->

**What kind of change does this PR introduce?**

I'm adding a change to install.sh that fixes a bug I was experiencing when trying the easy install on my Mac. The URL for the repo is using MLDSAI/OpenAdapt, but the repo url should be OpenAdaptAI/OpenAdapt. This should fix the error `fatal: repository 'https://github.com/https://github.com/MLDSAI/OpenAdapt.git/' not found` when running install.sh on mac. 

**Summary**

This change fixes Issue #501. The current install.sh script is using the wrong repo url when running `git clone`, so this change fixes that. 

**Checklist**
* [x] My code follows the style guidelines of OpenAdapt
* [x] I have performed a self-review of my code
* [x] If applicable, I have added tests to prove my fix is functional/effective
* [x] I have linted my code locally prior to submission
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [x] New and existing unit tests pass locally with my changes

**How can your code be run and tested?**

On Mac, open a new terminal and run ` /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/OpenAdaptAI/OpenAdapt/HEAD/install/install_openadapt.sh)"`
