### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ See how to set up system permissions on macOS [here](./permissions_in_macOS.md).
 
 ### Shell
 
-Run this in every new terminal window once before running any openadapt commands below:
+Run this in every new terminal window once (while inside the `OpenAdapt` root
+directory) before running any `openadapt` commands below:
 
 ```
 poetry shell


### PR DESCRIPTION
Clarify `poetry shell` needs to be run inside `OpenAdapt` root directory.