### PR TITLE
 Revert to use admin token for semantic release action

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -98,7 +98,7 @@ jobs:
         id: semantic_release
         uses: relekang/python-semantic-release@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ADMIN_TOKEN }} # Use the new token for authentication
           git_committer_name: "OpenAdapt Bot"
           git_committer_email: "bot@openadapt.ai"
       - name: Install the latest version of the project


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! To ensure a prompt review of your changes, please provide the following information. -->

**What kind of change does this PR introduce?**
This reverts a change that was made earlier, to use the `secrets.ADMIN_TOKEN` for the semantic release action

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Summary**
The `secrets.GITHUB_TOKEN` doesn't have the right privileges to push to the `main` branch, but the `secrets.ADMIN_TOKEN` does. This MR addresses that.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Try to link to an open issue. -->
https://github.com/OpenAdaptAI/OpenAdapt/actions/runs/8910687505/job/24470804634 - semantic release action failed because of wrong token

**Checklist**
* [x] My code follows the style guidelines of OpenAdapt
* [x] I have performed a self-review of my code
* [ ] If applicable, I have added tests to prove my fix is functional/effective
* [x] I have linted my code locally prior to submission
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [x] New and existing unit tests pass locally with my changes
