### PR TITLE
Revert to use admin token for release checkout action

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -84,6 +84,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.ADMIN_TOKEN }} # Use the new token for authentication
       - name: Download macOS executable
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! To ensure a prompt review of your changes, please provide the following information. -->

**What kind of change does this PR introduce?**
This reverts a change that was made earlier, to use the `secrets.ADMIN_TOKEN` for the release checkout action

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Summary**
It looks like because the checkout action was carried out with a token, there are issues in further actions when trying to push to the protected main branch.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Try to link to an open issue. -->
https://github.com/OpenAdaptAI/OpenAdapt/actions/runs/8910687505/job/24470804634 - semantic release action failed. The only change w.r.t tokens from when the action was passing, is the `secrets.ADMIN_TOKEN` being passed to the checkout action earlier

**Checklist**
* [x] My code follows the style guidelines of OpenAdapt
* [x] I have performed a self-review of my code
* [ ] If applicable, I have added tests to prove my fix is functional/effective
* [x] I have linted my code locally prior to submission
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [x] New and existing unit tests pass locally with my changes
