### PR TITLE
Restore `Config.ROOT_DIR_PATH`

### DIFF
--- a/openadapt/config.py
+++ b/openadapt/config.py
@@ -89,6 +89,8 @@ def get_json_config_settings_source(
 class Config(BaseSettings):
     """Configuration class for OpenAdapt."""
 
+    ROOT_DIR_PATH: str = str(ROOT_DIR_PATH)
+
     # Privacy
     PRIVATE_AI_API_KEY: str = ""
 


### PR DESCRIPTION
This was removed in a recent PR, which breaks everything that relies on `utils.render_template_from_file`.