### PR TITLE
 Run ci steps only if not triggered by the bot commit

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -6,9 +6,28 @@ on:
       - main
 
 jobs:
+  check_last_commit_author:
+    runs-on: ubuntu-latest
+    outputs:
+      skip_ci: ${{ steps.check_last_commit_author.outputs.skip_ci }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check last commit author
+        id: check_last_commit_author
+        run: |
+          LAST_COMMIT_AUTHOR=$(git log -1 --pretty=format:'%an')
+          if [ "$LAST_COMMIT_AUTHOR" = "OpenAdapt Bot" ]; then
+            echo "skip_ci=true" >> $GITHUB_OUTPUT
+          fi
+
   build-macos-executables:
     name: Build macOS app
     runs-on: macos-latest
+    needs: check_last_commit_author
+    if: ${{ needs.check_last_commit_author.outputs.skip_ci != 'true' }}
     steps:
         - name: Checkout repository
           uses: actions/checkout@v4
@@ -40,6 +59,8 @@ jobs:
   build-windows-executables:
     name: Build Windows app
     runs-on: windows-latest
+    needs: check_last_commit_author
+    if: ${{ needs.check_last_commit_author.outputs.skip_ci != 'true' }}
     steps:
         - name: Checkout repository
           uses: actions/checkout@v4
@@ -74,7 +95,8 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [build-macos-executables, build-windows-executables]
+    needs: [check_last_commit_author, build-macos-executables, build-windows-executables]
+    if: ${{ needs.check_last_commit_author.outputs.skip_ci != 'true' }}
     concurrency: release
     permissions:
       id-token: write
@@ -116,9 +138,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./build_scripts/upload_release_artifacts.sh
+
   publish:
     name: Publish to PyPI
-    needs: release
+    needs: [check_last_commit_author, release]
+    if: ${{ needs.check_last_commit_author.outputs.skip_ci != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! To ensure a prompt review of your changes, please provide the following information. -->

**What kind of change does this PR introduce?**
This PR fixes the issue where the commit made by the bot was triggering another workflow run, which wasn't needed because the previous workflow already had the most updated code

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Summary**
This includes a job that checks the last committer name, and skips all other jobs if the commiter was "OpenAdapt Bot"

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Try to link to an open issue. -->

**Checklist**
* [x] My code follows the style guidelines of OpenAdapt
* [x] I have performed a self-review of my code
* [ ] If applicable, I have added tests to prove my fix is functional/effective
* [x] I have linted my code locally prior to submission
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [x] New and existing unit tests pass locally with my changes

**How can your code be run and tested?**

<!-- See the README.md for examples. Include test output. -->


**Other information**
<!-- Delete this subheading if no additional context is needed. -->
