### PR TITLE
add hidden import replicate

### DIFF
--- a/openadapt/build.py
+++ b/openadapt/build.py
@@ -76,6 +76,7 @@ def main() -> None:
         "--windowed",
         "--hidden-import=tiktoken_ext.openai_public",
         "--hidden-import=tiktoken_ext",
+        "--hidden-import=replicate",
     ]
     ignore_dirs = [
         "__pycache__",


### PR DESCRIPTION
Fixes the following bug reported by user `technologicalpixel` on Discord:

```
Traceback (most recent call last):
  File "openadapt\entrypoint.py", line 11, in <module>
    from openadapt.app import tray
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "openadapt\app\tray.py", line 46, in <module>
    from openadapt.strategies.base import BaseReplayStrategy
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "openadapt\strategies\__init__.py", line 13, in <module>
    from openadapt.strategies.visual import VisualReplayStrategy
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "openadapt\strategies\visual.py", line 53, in <module>
    from openadapt import adapters, common, models, strategies, utils, vision
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "openadapt\adapters\__init__.py", line 7, in <module>
    from . import anthropic, google, openai, replicate, som, ultralytics
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "openadapt\adapters\replicate.py", line 9, in <module>
    import replicate
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "replicate\__init__.py", line 1, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "replicate\client.py", line 22, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "replicate\__about__.py", line 3, in <module>
  File "importlib\metadata\__init__.py", line 996, in version
  File "importlib\metadata\__init__.py", line 969, in distribution
  File "importlib\metadata\__init__.py", line 548, in from_name
importlib.metadata.PackageNotFoundError: No package metadata was found for replicate
```
![image](https://github.com/OpenAdaptAI/OpenAdapt/assets/774615/ca9449ff-b722-43e4-8435-09c79535e600)
