### PR TITLE
Fix `openadapt.visualize` and `get_audio_info`

### DIFF
--- a/openadapt/app/dashboard/api/recordings.py
+++ b/openadapt/app/dashboard/api/recordings.py
@@ -83,8 +83,7 @@ class RecordingsAPI:
             )
 
             try:
-                # TODO: change to use recording_id once scrubbing PR is merged
-                audio_info = crud.get_audio_info(session, recording.timestamp)[0]
+                audio_info = crud.get_audio_info(session, recording)[0]
                 words_with_timestamps = json.loads(audio_info.words_with_timestamps)
                 words_with_timestamps = [
                     {

--- a/openadapt/app/dashboard/api/recordings.py
+++ b/openadapt/app/dashboard/api/recordings.py
@@ -83,7 +83,7 @@ class RecordingsAPI:
             )
 
             try:
-                audio_info = crud.get_audio_info(session, recording)[0]
+                audio_info = crud.get_audio_info(session, recording)
                 words_with_timestamps = json.loads(audio_info.words_with_timestamps)
                 words_with_timestamps = [
                     {

--- a/openadapt/db/crud.py
+++ b/openadapt/db/crud.py
@@ -678,7 +678,7 @@ def insert_audio_info(
 def get_audio_info(
     session: SaSession,
     recording: Recording,
-) -> list[AudioInfo]:
+) -> AudioInfo:
     """Get the audio info for a given recording.
 
     Args:
@@ -686,9 +686,10 @@ def get_audio_info(
         recording (Recording): The recording object.
 
     Returns:
-        list[AudioInfo]: A list of audio info for the recording.
+        AudioInfo: Audio info for the recording.
     """
-    return _get(session, AudioInfo, recording.id)
+    audio_infos = _get(session, AudioInfo, recording.id)
+    return audio_infos[0] if audio_infos else None
 
 
 def post_process_events(session: SaSession, recording: Recording) -> None:

--- a/openadapt/db/crud.py
+++ b/openadapt/db/crud.py
@@ -675,7 +675,7 @@ def insert_audio_info(
     session.commit()
 
 
-# TODO: change to use recording_id once scrubbing PR is merged
+# XXX TODO: change to use recording_id once scrubbing PR is merged
 def get_audio_info(
     session: SaSession,
     recording_timestamp: float,

--- a/openadapt/db/crud.py
+++ b/openadapt/db/crud.py
@@ -675,21 +675,20 @@ def insert_audio_info(
     session.commit()
 
 
-# XXX TODO: change to use recording_id once scrubbing PR is merged
 def get_audio_info(
     session: SaSession,
-    recording_timestamp: float,
+    recording: Recording,
 ) -> list[AudioInfo]:
     """Get the audio info for a given recording.
 
     Args:
         session (sa.orm.Session): The database session.
-        recording_timestamp (float): The timestamp of the recording.
+        recording (Recording): The recording object.
 
     Returns:
         list[AudioInfo]: A list of audio info for the recording.
     """
-    return _get(session, AudioInfo, recording_timestamp)
+    return _get(session, AudioInfo, recording.id)
 
 
 def post_process_events(session: SaSession, recording: Recording) -> None:

--- a/openadapt/utils.py
+++ b/openadapt/utils.py
@@ -98,6 +98,8 @@ def row2dict(row: dict | db.BaseModel, follow: bool = True) -> dict:
     Returns:
         dict: The row object converted to a dictionary.
     """
+    if not row:
+        return {}
     if isinstance(row, dict):
         return row
     try_follow = ["children"] if follow else []

--- a/openadapt/visualize.py
+++ b/openadapt/visualize.py
@@ -186,7 +186,6 @@ def main(
     logger.info(f"{recording=}")
     logger.info(f"{diff_video=}")
 
-
     session = crud.get_new_session(read_only=True)
     audio_info = row2dict(crud.get_audio_info(session, recording))
     if audio_info:

--- a/openadapt/visualize.py
+++ b/openadapt/visualize.py
@@ -186,7 +186,9 @@ def main(
     logger.info(f"{recording=}")
     logger.info(f"{diff_video=}")
 
-    audio_info = row2dict(crud.get_audio_info(recording))
+
+    session = crud.get_new_session(read_only=True)
+    audio_info = row2dict(crud.get_audio_info(session, recording))
     # don't display the FLAC data
     del audio_info["flac_data"]
 

--- a/openadapt/visualize.py
+++ b/openadapt/visualize.py
@@ -189,8 +189,9 @@ def main(
 
     session = crud.get_new_session(read_only=True)
     audio_info = row2dict(crud.get_audio_info(session, recording))
-    # don't display the FLAC data
-    del audio_info["flac_data"]
+    if audio_info:
+        del audio_info["flac_data"]
+    # TODO XXX: display audio_info
 
     if diff_video:
         assert recording.config[


### PR DESCRIPTION
Currently `openadapt.visualize` produces an Exception on main:

```
  File "/Users/abrichr/oa/OpenAdapt/openadapt/visualize.py", line 189, in main
    audio_info = row2dict(crud.get_audio_info(recording))
                 |        |    |              -> Recording(id=13, timestamp=1717686247.322987, monitor_width=1512, monitor_height=982, double_click_interval_seconds=0.5, doub...
                 |        |    -> <function get_audio_info at 0x1695b2710>
                 |        -> <module 'openadapt.db.crud' from '/Users/abrichr/oa/OpenAdapt/openadapt/db/crud.py'>
                 -> <function row2dict at 0x1694e8160>

TypeError: get_audio_info() missing 1 required positional argument: 'recording_timestamp'
```

Seems related:
```
# TODO: change to use recording_id once scrubbing PR is merged
def get_audio_info(
    session: SaSession,
    recording_timestamp: float,
) -> list[AudioInfo]:
```