### PR TITLE
Fix video playback with force_key_frame

### DIFF
--- a/openadapt/config.defaults.json
+++ b/openadapt/config.defaults.json
@@ -21,7 +21,6 @@
     "RECORD_FULL_VIDEO": false,
     "RECORD_IMAGES": false,
     "LOG_MEMORY": false,
-    "VIDEO_PIXEL_FORMAT": "rgb24",
     "STOP_SEQUENCES": [
         [
             "o",

--- a/openadapt/config.py
+++ b/openadapt/config.py
@@ -148,7 +148,7 @@ class Config(BaseSettings):
     LOG_MEMORY: bool
     REPLAY_STRIP_ELEMENT_STATE: bool = True
     VIDEO_ENCODING: str = "libx264"
-    VIDEO_PIXEL_FORMAT: str = "yuv420p"
+    VIDEO_PIXEL_FORMAT: str = "yuv444p"
     VIDEO_DIR_PATH: str = str(VIDEO_DIR_PATH)
     # sequences that when typed, will stop the recording of ActionEvents in record.py
     STOP_SEQUENCES: list[list[str]] = [

--- a/openadapt/config.py
+++ b/openadapt/config.py
@@ -147,7 +147,8 @@ class Config(BaseSettings):
     # useful for debugging but expensive computationally
     LOG_MEMORY: bool
     REPLAY_STRIP_ELEMENT_STATE: bool = True
-    VIDEO_PIXEL_FORMAT: str = "rgb24"
+    VIDEO_ENCODING: str = "libx264"
+    VIDEO_PIXEL_FORMAT: str = "yuv420p"
     VIDEO_DIR_PATH: str = str(VIDEO_DIR_PATH)
     # sequences that when typed, will stop the recording of ActionEvents in record.py
     STOP_SEQUENCES: list[list[str]] = [

--- a/openadapt/record.py
+++ b/openadapt/record.py
@@ -411,6 +411,7 @@ def video_pre_callback(db: crud.SaSession, recording: Recording) -> dict[str, An
         "video_stream": video_stream,
         "video_start_timestamp": video_start_timestamp,
         "last_pts": 0,
+        "video_file_path": video_file_path,
     }
 
 
@@ -427,6 +428,7 @@ def video_post_callback(state: dict) -> None:
         state["last_frame"],
         state["last_frame_timestamp"],
         state["last_pts"],
+        state["video_file_path"],
     )
 
 
@@ -439,7 +441,6 @@ def write_video_event(
     video_stream: av.stream.Stream,
     video_start_timestamp: float,
     last_pts: int = 0,
-    num_copies: int = 2,
     **kwargs,
 ) -> dict[str, Any]:
     """Write a screen event to the video file and update the performance queue.
@@ -455,33 +456,33 @@ def write_video_event(
         video_start_timestamp (float): The base timestamp from which the video
             recording started.
         last_pts: The last presentation timestamp.
-        num_copies: The number of times to write the first each frame.
 
     Returns:
         dict containing state.
     """
-    if last_pts != 0:
-        num_copies = 1
     screenshot_image = event.data
     screenshot_timestamp = event.timestamp
-    # ensure that the first frame is available (otherwise occasionally it is not)
-    for _ in range(num_copies):
-        last_pts = video.write_video_frame(
-            video_container,
-            video_stream,
-            screenshot_image,
-            screenshot_timestamp,
-            video_start_timestamp,
-            last_pts,
-        )
+    force_key_frame = last_pts == 0
+    last_pts = video.write_video_frame(
+        video_container,
+        video_stream,
+        screenshot_image,
+        screenshot_timestamp,
+        video_start_timestamp,
+        last_pts,
+        force_key_frame,
+    )
     perf_q.put((f"{event.type}(video)", event.timestamp, utils.get_timestamp()))
     return {
-        "video_container": video_container,
-        "video_stream": video_stream,
-        "video_start_timestamp": video_start_timestamp,
-        "last_frame": screenshot_image,
-        "last_frame_timestamp": screenshot_timestamp,
-        "last_pts": last_pts,
+        **kwargs,
+        **{
+            "video_container": video_container,
+            "video_stream": video_stream,
+            "video_start_timestamp": video_start_timestamp,
+            "last_frame": screenshot_image,
+            "last_frame_timestamp": screenshot_timestamp,
+            "last_pts": last_pts,
+        },
     }
 
 

--- a/openadapt/record.py
+++ b/openadapt/record.py
@@ -423,6 +423,10 @@ def video_post_callback(state: dict) -> None:
     video.finalize_video_writer(
         state["video_container"],
         state["video_stream"],
+        state["video_start_timestamp"],
+        state["last_frame"],
+        state["last_frame_timestamp"],
+        state["last_pts"],
     )
 
 
@@ -436,6 +440,7 @@ def write_video_event(
     video_start_timestamp: float,
     last_pts: int = 0,
     num_copies: int = 2,
+    **kwargs,
 ) -> dict[str, Any]:
     """Write a screen event to the video file and update the performance queue.
 
@@ -457,13 +462,15 @@ def write_video_event(
     """
     if last_pts != 0:
         num_copies = 1
+    screenshot_image = event.data
+    screenshot_timestamp = event.timestamp
     # ensure that the first frame is available (otherwise occasionally it is not)
     for _ in range(num_copies):
         last_pts = video.write_video_frame(
             video_container,
             video_stream,
-            event.data,
-            event.timestamp,
+            screenshot_image,
+            screenshot_timestamp,
             video_start_timestamp,
             last_pts,
         )
@@ -472,6 +479,8 @@ def write_video_event(
         "video_container": video_container,
         "video_stream": video_stream,
         "video_start_timestamp": video_start_timestamp,
+        "last_frame": screenshot_image,
+        "last_frame_timestamp": screenshot_timestamp,
         "last_pts": last_pts,
     }
 

--- a/openadapt/record.py
+++ b/openadapt/record.py
@@ -441,7 +441,7 @@ def write_video_event(
     video_stream: av.stream.Stream,
     video_start_timestamp: float,
     last_pts: int = 0,
-    **kwargs,
+    **kwargs: dict,
 ) -> dict[str, Any]:
     """Write a screen event to the video file and update the performance queue.
 

--- a/openadapt/video.py
+++ b/openadapt/video.py
@@ -189,7 +189,7 @@ def finalize_video_writer(
         video_container,
         video_stream,
         last_frame,
-		last_frame_timestamp,
+        last_frame_timestamp,
         video_start_timestamp,
         last_pts,
         force_key_frame=True,
@@ -225,7 +225,7 @@ def finalize_video_writer(
     logger.info("done")
 
 
-def move_moov_atom(input_file: str, output_file: str = None):
+def move_moov_atom(input_file: str, output_file: str = None) -> None:
     """Moves the moov atom to the beginning of the video file using ffmpeg.
 
     If no output file is specified, modifies the input file in place.
@@ -238,17 +238,22 @@ def move_moov_atom(input_file: str, output_file: str = None):
     if output_file is None:
         # Create a temporary file
         temp_file = tempfile.NamedTemporaryFile(
-            delete=False, suffix='.mp4', dir=os.path.dirname(input_file),
+            delete=False,
+            suffix=".mp4",
+            dir=os.path.dirname(input_file),
         ).name
         output_file = temp_file
 
     command = [
-        'ffmpeg',
-        '-y',  # Automatically overwrite files without asking
-        '-i', input_file,
-        '-codec', 'copy',  # Avoid re-encoding; just copy streams
-        '-movflags', 'faststart',  # Move the moov atom to the start
-        output_file
+        "ffmpeg",
+        "-y",  # Automatically overwrite files without asking
+        "-i",
+        input_file,
+        "-codec",
+        "copy",  # Avoid re-encoding; just copy streams
+        "-movflags",
+        "faststart",  # Move the moov atom to the start
+        output_file,
     ]
     logger.info(f"{command=}")
     subprocess.run(command, check=True)

--- a/openadapt/video.py
+++ b/openadapt/video.py
@@ -163,6 +163,7 @@ def finalize_video_writer(
     last_frame_timestamp: float,
     last_pts: int,
     video_file_path: str,
+    fix_moov: bool = False,
 ) -> None:
     """Finalizes the video writer, ensuring all buffered frames are encoded and written.
 
@@ -175,6 +176,10 @@ def finalize_video_writer(
         last_frame_timestamp (float): The timestamp of the last frame that was written.
         last_pts (int): The last presentation timestamp.
         video_file_path (str): The path to the video file.
+        fix_moov (bool): Whether to move the moov atom to the beginning of the file.
+            Setting this to True will fix a bug when displaying the video in Github
+            comments causing the video to appear to start a few seconds after 0:00.
+            However, this causes extract_frames to fail.
     """
     # Closing the container in the main thread leads to a GIL deadlock.
     # https://github.com/PyAV-Org/PyAV/issues/1053
@@ -212,7 +217,10 @@ def finalize_video_writer(
     close_thread.join()
 
     # Move moov atom to beginning of file
-    #move_moov_atom(video_file_path)
+    if fix_moov:
+        # TODO: fix this
+        logger.warning("{fix_mov=} will cause extract_frames() to fail!!!")
+        move_moov_atom(video_file_path)
 
     logger.info("done")
 

--- a/openadapt/video.py
+++ b/openadapt/video.py
@@ -212,7 +212,7 @@ def finalize_video_writer(
     close_thread.join()
 
     # Move moov atom to beginning of file
-    move_moov_atom(video_file_path)
+    #move_moov_atom(video_file_path)
 
     logger.info("done")
 

--- a/openadapt/video.py
+++ b/openadapt/video.py
@@ -219,7 +219,7 @@ def finalize_video_writer(
     # Move moov atom to beginning of file
     if fix_moov:
         # TODO: fix this
-        logger.warning("{fix_mov=} will cause extract_frames() to fail!!!")
+        logger.warning(f"{fix_moov=} will cause extract_frames() to fail!!!")
         move_moov_atom(video_file_path)
 
     logger.info("done")

--- a/tests/openadapt/test_video.py
+++ b/tests/openadapt/test_video.py
@@ -3,4 +3,4 @@
 # from openadapt import models, video
 
 
-# TODO: compare diff shown in in deprecated.visualize(diff_video=True)
+# TODO: compare diff shown in deprecated.visualize(diff_video=True)


### PR DESCRIPTION
This PR fixes the video produced by video.py so that it can be played back in Github comments.

Before:

https://github.com/OpenAdaptAI/OpenAdapt/assets/774615/e5caa534-28fa-4fb1-8815-b64bd72620a6

After:

With `fix_moov=True`:

https://github.com/OpenAdaptAI/OpenAdapt/assets/774615/7be10a38-5f0d-4346-8cfc-f1e2f140a0e2

```
2024-06-08 12:21:46.570 | INFO     | openadapt.video:extract_frames:233 - frame_differences=               
{2.683544874191284: 0.01687820752461766,                                                                                                                                                                              
 2.853571653366089: 0.06309501330057765,                                                                                                                                                                               2.887784957885742: 0.07054837544759085,                                                                                                                                                                              
 2.928327798843384: 0.07167220115661621,                                                                                                                                                                              
 2.985595464706421: 0.09773786862691214,                                                                   
 3.073902130126953: 0.009431203206379912,                                                                                                                                                                             
 3.106308698654175: 0.022975365320841767,                                                                                                                                                                             
 3.219935894012451: inf,                                                                                                                                                                                              
 3.2490646839141846: inf,                                                                                  
 3.292484998703003: 0.08251500129699707,                                                                                                                                                                              
 3.3331282138824463: 0.08353845278422023,
...
  File "/Users/abrichr/oa/OpenAdapt/openadapt/video.py", line 238, in extract_frames
    raise Exception(                    
                                                     
Exception: No frame found within tolerance for timestamp 3.219935894012451s.
```

With `fix_moov=False`:

```
    VIDEO_PIXEL_FORMAT: str = "yuv420p"
```
https://github.com/OpenAdaptAI/OpenAdapt/assets/774615/74342bbe-49d1-454a-9d93-a7d06daed7cb

```
    VIDEO_PIXEL_FORMAT: str = "yuv444p"
```
https://github.com/OpenAdaptAI/OpenAdapt/assets/774615/bd8976d3-707e-4293-a6b8-00d8bc89bfc7



