### PR TITLE
Posthog event logging updates

### DIFF
--- a/openadapt/app/tray.py
+++ b/openadapt/app/tray.py
@@ -62,13 +62,18 @@ class TrackedQAction(QAction):
             text (str): The text of the action.
             parent (QWidget): The parent widget.
         """
+        self.tracking_text = kwargs.pop("tracking_text", None)
         super().__init__(*args, **kwargs)
+        if not self.tracking_text:
+            self.tracking_text = self.text()
         self.triggered.connect(self.track_event)
 
     def track_event(self) -> None:
         """Track the event."""
         posthog = get_posthog_instance()
-        posthog.capture(event="action_triggered", properties={"action": self.text()})
+        posthog.capture(
+            event="action_triggered", properties={"action": self.tracking_text}
+        )
 
 
 class SystemTrayIcon:
@@ -454,7 +459,9 @@ class SystemTrayIcon:
                     recording.timestamp
                 ).strftime("%Y-%m-%d %H:%M:%S")
                 action_text = f"{formatted_timestamp}: {recording.task_description}"
-                recording_action = TrackedQAction(action_text)
+                recording_action = TrackedQAction(
+                    action_text, tracking_text=f"{action_type.title()} recording"
+                )
                 recording_action.triggered.connect(partial(action, recording))
                 self.recording_actions[action_type].append(recording_action)
                 menu.addAction(recording_action)

--- a/openadapt/plotting.py
+++ b/openadapt/plotting.py
@@ -4,18 +4,17 @@ from collections import defaultdict
 from io import BytesIO
 import math
 import os
-import unicodedata
 import sys
+import unicodedata
 
-
-import matplotlib.pyplot as plt
-import numpy as np
 from loguru import logger
 from PIL import Image, ImageDraw, ImageEnhance, ImageFont
+import matplotlib.pyplot as plt
+import numpy as np
 
+from openadapt import common, utils
 from openadapt.config import PERFORMANCE_PLOTS_DIR_PATH, config
 from openadapt.models import ActionEvent
-from openadapt import common, utils
 
 
 # TODO: move parameters to config
@@ -347,9 +346,11 @@ def plot_performance(
     # avoid circular import
     from openadapt.db import crud
 
+    session = crud.get_new_session(read_only=True)
+
     if not recording_timestamp:
-        recording_timestamp = crud.get_latest_recording().timestamp
-    perf_stats = crud.get_perf_stats(recording_timestamp)
+        recording_timestamp = crud.get_latest_recording(session).timestamp
+    perf_stats = crud.get_perf_stats(session, recording_timestamp)
     for perf_stat in perf_stats:
         event_type = perf_stat.event_type
         start_time = perf_stat.start_time
@@ -366,7 +367,7 @@ def plot_performance(
     ax.legend()
     ax.set_ylabel("Duration (seconds)")
 
-    mem_stats = crud.get_memory_stats(recording_timestamp)
+    mem_stats = crud.get_memory_stats(session, recording_timestamp)
     timestamps = []
     mem_usages = []
     for mem_stat in mem_stats:

--- a/openadapt/utils.py
+++ b/openadapt/utils.py
@@ -9,6 +9,7 @@ from logging import StreamHandler
 from typing import Any, Callable
 import ast
 import base64
+import importlib.metadata
 import inspect
 import os
 import sys
@@ -893,6 +894,12 @@ class DistinctIDPosthog(Posthog):
             **kwargs: The event properties.
         """
         kwargs.setdefault("distinct_id", config.UNIQUE_USER_ID)
+        properties = kwargs.get("properties", {})
+        properties.setdefault("version", importlib.metadata.version("openadapt"))
+        if not is_running_from_executable():
+            # for cases when we need to test events in development
+            properties.setdefault("is_development", True)
+        kwargs["properties"] = properties
         super().capture(*args, **kwargs)
 
 

--- a/tests/openadapt/test_utils.py
+++ b/tests/openadapt/test_utils.py
@@ -22,10 +22,16 @@ def test_get_scale_ratios() -> None:
 def test_posthog_capture() -> None:
     """Tests utils.get_posthog_instance."""
     with patch("posthog.Posthog.capture") as mock_capture:
-        posthog = utils.get_posthog_instance()
-        posthog.capture(event="test_event", properties={"test_prop": "test_val"})
-        mock_capture.assert_called_once_with(
-            event="test_event",
-            properties={"test_prop": "test_val"},
-            distinct_id=config.UNIQUE_USER_ID,
-        )
+        with patch("importlib.metadata.version") as mock_version:
+            mock_version.return_value = "1.0.0"
+            posthog = utils.get_posthog_instance()
+            posthog.capture(event="test_event", properties={"test_prop": "test_val"})
+            mock_capture.assert_called_once_with(
+                event="test_event",
+                properties={
+                    "test_prop": "test_val",
+                    "version": "1.0.0",
+                    "is_development": True,
+                },
+                distinct_id=config.UNIQUE_USER_ID,
+            )


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! To ensure a prompt review of your changes, please provide the following information. -->

**What kind of change does this PR introduce?**
This PR adds a version number of the openadapt build to posthog events, so its easier to debug the source of erroneous events. It also adds a fix so that submenus in the tray, that have the name of the recording are not reported, rather the underlying action is reported
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Summary**
Address #768 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Try to link to an open issue. -->

**Checklist**
* [x] My code follows the style guidelines of OpenAdapt
* [x] I have performed a self-review of my code
* [ ] If applicable, I have added tests to prove my fix is functional/effective
* [x] I have linted my code locally prior to submission
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [x] New and existing unit tests pass locally with my changes

**How can your code be run and tested?**
In `utils.py`, comment out the lines that disable posthog in the `get_posthog_instance` function. I have added a property to psothog events that will differentiate dev events from events coming from the app, so this can be used when we need to test without polluting the events charts. Play around with the tray (also the submenus) and check that the events are logged correctly
