### PR TITLE
Fix error when downloading whisper model

### DIFF
--- a/openadapt/app/dashboard/app/recordings/page.tsx
+++ b/openadapt/app/dashboard/app/recordings/page.tsx
@@ -50,7 +50,7 @@ export default function Recordings() {
     }, []);
     return (
         <Box>
-            {/* {recordingStatus === RecordingStatus.RECORDING && (
+            {recordingStatus === RecordingStatus.RECORDING && (
                 <Button onClick={stopRecording} variant="outline" color="red">
                     Stop recording
                 </Button>
@@ -64,7 +64,7 @@ export default function Recordings() {
                 <Button variant="outline" color="blue">
                     Loading recording status...
                 </Button>
-            )} */}
+            )}
             <Tabs defaultValue="regular" mt={40}>
                 <Tabs.List>
                     <Tabs.Tab value="regular">

--- a/openadapt/record.py
+++ b/openadapt/record.py
@@ -1078,7 +1078,8 @@ def record_audio(
 
     # Convert audio to text using OpenAI's Whisper
     logger.info("Transcribing audio...")
-    model = whisper.load_model("base")
+    with redirect_stdout_stderr():
+        model = whisper.load_model("base")
     result_info = model.transcribe(converted_audio, word_timestamps=True, fp16=False)
     logger.info(f"The narrated text is: {result_info['text']}")
     # empty word_list if the user didn't say anything


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! To ensure a prompt review of your changes, please provide the following information. -->

**What kind of change does this PR introduce?**
This PR addresses #815 

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Summary**
This PR fixes the exception that was being raised when downloading the whisper model for the first time in an application. Whisper internally uses `tqdm` for the download progress bar, which was causing issues when there was no `sys.stdout` present.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Try to link to an open issue. -->

**Checklist**
* [x] My code follows the style guidelines of OpenAdapt
* [x] I have performed a self-review of my code
* [ ] If applicable, I have added tests to prove my fix is functional/effective
* [x] I have linted my code locally prior to submission
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [x] New and existing unit tests pass locally with my changes

**How can your code be run and tested?**
To test this, first reproduce the bug
- Checkout to `main` branch
- Go to the path output by `os.path.join(os.path.expanduser("~"), ".cache")` and delete the `whisper` directory if its present.
- Build the app using `python -m openadapt.build` and then run the built app and start then stop recording. You should see the error window.

Then checkout to this branch, delete the `whisper` directory again, then build and run the app, start and stop the recording. The recording should stop without errors.
