### PR TITLE
Update release-and-publish.yml: replace GITHUB_TOKEN with ADMIN_TOKEN

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ADMIN_TOKEN }}
       - name: Check last commit author
         id: check_last_commit_author
         run: |


### PR DESCRIPTION
Fix broken release (https://github.com/OpenAdaptAI/OpenAdapt/actions/runs/9813501659/job/27099922783)