### PR TITLE
Fix recording not working because of bug in read window data

### DIFF
--- a/openadapt/window/_windows.py
+++ b/openadapt/window/_windows.py
@@ -1,8 +1,10 @@
 from pprint import pprint
+from typing import TYPE_CHECKING
 import pickle
 import time
 
-import pywinauto
+if TYPE_CHECKING:
+    import pywinauto
 
 from openadapt.custom_logger import logger
 
@@ -53,7 +55,7 @@ def get_active_window_state(read_window_data: bool) -> dict:
 
 
 def get_active_window_meta(
-    active_window: pywinauto.application.WindowSpecification,
+    active_window: "pywinauto.application.WindowSpecification",
 ) -> dict:
     """Get the meta information of the active window.
 
@@ -88,18 +90,22 @@ def get_active_element_state(x: int, y: int) -> dict:
     return properties
 
 
-def get_active_window() -> pywinauto.application.WindowSpecification:
+def get_active_window() -> "pywinauto.application.WindowSpecification":
     """Get the active window object.
 
     Returns:
         pywinauto.application.WindowSpecification: The active window object.
     """
+    import pywinauto
+
     app = pywinauto.application.Application(backend="uia").connect(active_only=True)
     window = app.top_window()
     return window.wrapper_object()
 
 
-def get_element_properties(element: pywinauto.application.WindowSpecification) -> dict:
+def get_element_properties(
+    element: "pywinauto.application.WindowSpecification",
+) -> dict:
     """Recursively retrieves the properties of each element and its children.
 
     Args:
@@ -132,7 +138,7 @@ def get_element_properties(element: pywinauto.application.WindowSpecification) -
     return properties
 
 
-def dictify_rect(rect: pywinauto.win32structures.RECT) -> dict:
+def dictify_rect(rect: "pywinauto.win32structures.RECT") -> dict:
     """Convert a rectangle object to a dictionary.
 
     Args:
@@ -150,7 +156,7 @@ def dictify_rect(rect: pywinauto.win32structures.RECT) -> dict:
     return rect_dict
 
 
-def get_properties(element: pywinauto.application.WindowSpecification) -> dict:
+def get_properties(element: "pywinauto.application.WindowSpecification") -> dict:
     """Retrieves specific writable properties of an element.
 
     This function retrieves a dictionary of writable properties for a given element.
@@ -168,6 +174,7 @@ def get_properties(element: pywinauto.application.WindowSpecification) -> dict:
 
     """
     _element_class = element.__class__
+    import pywinauto
 
     class TempElement(element.__class__):
         writable_props = pywinauto.base_wrapper.BaseWrapper.writable_props


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! To ensure a prompt review of your changes, please provide the following information. -->

**What kind of change does this PR introduce?**
Fixes #904 

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Summary**
This PR fixes the bug where recording was stuck in windows, because the app wasn't able to read the active window data.

Because of how pywinauto works, simply importing it causes it to set a value of the COM threading mode, that cannot be changed after that. When recording is started, the threading mode is set first, but then other threads try and change the mode, which causes the app to freeze, because changing modes is not allowed. This is also the reason you see the warning `warnings.warn("Revert to STA COM threading mode", UserWarning)`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Try to link to an open issue. -->

**Checklist**
* [x] My code follows the style guidelines of OpenAdapt
* [x] I have performed a self-review of my code
* [ ] If applicable, I have added tests to prove my fix is functional/effective
* [x] I have linted my code locally prior to submission
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation (e.g. README.md, requirements.txt)
* [x] New and existing unit tests pass locally with my changes

**How can your code be run and tested?**
Try and run the following on windows
```python
 python -m openadapt.record "testing openadapt record"
```
<!-- See the README.md for examples. Include test output. -->
