### PR TITLE
Support multiple monitors

### DIFF
--- a/openadapt/record.py
+++ b/openadapt/record.py
@@ -722,14 +722,15 @@ def read_screen_events(
     logger.info("Starting")
     started = False
     while not terminate_processing.is_set():
-        screenshot = utils.take_screenshot()
-        if screenshot is None:
-            logger.warning("Screenshot was None")
+        screenshots = utils.take_screenshots()
+        if not screenshots:
+            logger.warning("Screenshots were None")
             continue
         if not started:
             started_event.set()
             started = True
-        event_q.put(Event(utils.get_timestamp(), "screen", screenshot))
+        for screenshot in screenshots:
+            event_q.put(Event(utils.get_timestamp(), "screen", screenshot))
     logger.info("Done")
 
 

--- a/openadapt/utils.py
+++ b/openadapt/utils.py
@@ -467,12 +467,26 @@ def take_screenshot() -> Image.Image:
     Returns:
         PIL.Image: The screenshot image.
     """
-    # monitor 0 is all in one
     sct = get_process_local_sct()
     monitor = sct.monitors[0]
     sct_img = sct.grab(monitor)
     image = Image.frombytes("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX")
     return image
+
+
+def take_screenshots() -> list[Image.Image]:
+    """Take screenshots of all monitors.
+
+    Returns:
+        list[PIL.Image]: List of screenshot images from all monitors.
+    """
+    sct = get_process_local_sct()
+    screenshots = []
+    for monitor in sct.monitors[1:]:
+        sct_img = sct.grab(monitor)
+        image = Image.frombytes("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX")
+        screenshots.append(image)
+    return screenshots
 
 
 def get_strategy_class_by_name() -> dict:
@@ -629,6 +643,7 @@ def parse_code_snippet(snippet: str) -> dict:
         ```json
         { "foo": true }
         ```
+
     Returns:
 
         { "foo": True }

--- a/openadapt/visualize.py
+++ b/openadapt/visualize.py
@@ -33,6 +33,7 @@ from openadapt.utils import (
     row2dict,
     rows2dicts,
     truncate_html,
+    take_screenshots,
 )
 
 SCRUB = config.SCRUB_ENABLED
@@ -436,6 +437,28 @@ def main(
                 progress.update()
 
             progress.close()
+
+    # Display screenshots from all monitors
+    screenshots = take_screenshots()
+    for idx, screenshot in enumerate(screenshots):
+        screenshot_utf8 = image2utf8(screenshot)
+        width, height = screenshot.size
+        rows.append(
+            row(
+                Div(
+                    text=f"""
+                    <div class="screenshot">
+                        <img
+                            src="{screenshot_utf8}"
+                            style="
+                                aspect-ratio: {width}/{height};
+                            "
+                        >
+                    </div>
+                """,
+                ),
+            )
+        )
 
     title = f"recording-{recording.id}"
 

--- a/tests/openadapt/test_utils.py
+++ b/tests/openadapt/test_utils.py
@@ -35,3 +35,12 @@ def test_posthog_capture() -> None:
                 },
                 distinct_id=config.UNIQUE_USER_ID,
             )
+
+
+def test_take_screenshots() -> None:
+    """Tests utils.take_screenshots."""
+    screenshots = utils.take_screenshots()
+
+    assert isinstance(screenshots, list), f"Expected list, got {type(screenshots).__name__}"
+    for screenshot in screenshots:
+        assert isinstance(screenshot, utils.Image.Image), f"Expected PIL.Image, got {type(screenshot).__name__}"


### PR DESCRIPTION
Related to #766

Add support for multiple monitors and provide screenshots of the visualization containing more than one monitor.

* **openadapt/utils.py**
  - Update `take_screenshot` function to iterate through all monitors and capture screenshots.
  - Add a new function `take_screenshots` to return a list of screenshots from all monitors.

* **openadapt/visualize.py**
  - Modify `main` function to handle and display screenshots from multiple monitors.
  - Update the HTML generation logic to include screenshots from all monitors.

* **openadapt/record.py**
  - Update `read_screen_events` function to support capturing screenshots from multiple monitors.

* **tests/openadapt/test_utils.py**
  - Add unit tests for the new `take_screenshots` function.

