### PR TITLE
docs: add blog link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Record GUI demonstrations, train ML models, and evaluate agents - all from a unified CLI.
 
-[Join us on Discord](https://discord.gg/yF527cQbDG) | [Documentation](https://docs.openadapt.ai) | [OpenAdapt.ai](https://openadapt.ai)
+[Join us on Discord](https://discord.gg/yF527cQbDG) | [Documentation](https://docs.openadapt.ai) | [Blog](https://blog.openadapt.ai) | [OpenAdapt.ai](https://openadapt.ai)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add cross-link to https://blog.openadapt.ai in the README links bar
- The blog currently has zero Google indexing; linking from the high-traffic README (1500+ stars) gives it discoverability

## Test plan
- [x] Verify the link renders correctly in GitHub's markdown preview
- [x] Verify https://blog.openadapt.ai resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)