### PR TITLE
fix: repair broken openadapt-ml imports in serve and train CLI commands

### DIFF
--- a/openadapt/cli.py
+++ b/openadapt/cli.py
@@ -196,23 +196,40 @@ def train_start(
     try:
         click.echo("Starting training...")
         click.echo(f"  Capture: {capture}")
-        click.echo(f"  Model: {model}")
         click.echo(f"  Output: {output}")
 
-        # Import and run training
-        from openadapt_ml.scripts.train import train_main
+        # Import and run training. The model is determined by the config
+        # file; --model is kept for backward compatibility only.
+        from openadapt_ml.scripts.train import main as train_main
+
+        if not config:
+            from openadapt_ml.cloud.local import detect_device
+
+            if "cuda" in detect_device():
+                config = "configs/qwen3vl_capture.yaml"
+            else:
+                config = "configs/qwen3vl_capture_4bit.yaml"
+        try:
+            from openadapt_ml.cloud.local import resolve_config_path
+
+            config = str(resolve_config_path(config))
+        except ImportError:
+            # Older openadapt-ml without resolve_config_path; use as-is.
+            pass
+        click.echo(f"  Config: {config}")
 
         train_main(
-            capture=capture,
-            model=model,
-            config=config,
+            config_path=config,
+            capture_path=capture,
             output_dir=output,
             open_dashboard=open,
         )
 
-    except ImportError:
-        click.echo("Error: openadapt-ml not installed.", err=True)
-        click.echo("Install with: pip install openadapt-ml", err=True)
+    except ImportError as e:
+        click.echo(f"Error: failed to import openadapt-ml ({e}).", err=True)
+        click.echo(
+            'Install with: pip install "openadapt-ml[training]"', err=True
+        )
         sys.exit(1)
 
 
@@ -405,16 +422,35 @@ def serve(port: int, output: str, open: bool):
         click.echo(f"Starting server on port {port}...")
         click.echo(f"Serving from: {output}")
 
-        from openadapt_ml.cloud.local import serve_dashboard
+        import argparse
 
-        serve_dashboard(
-            output_dir=output,
-            port=port,
-            open_browser=open,
+        from openadapt_ml.cloud.local import cmd_serve
+
+        if open:
+            import threading
+            import webbrowser
+
+            threading.Timer(
+                1.0, webbrowser.open, args=(f"http://localhost:{port}",)
+            ).start()
+
+        # cmd_serve serves the 'current' training run from the working
+        # directory's training_output; it takes an argparse Namespace.
+        sys.exit(
+            cmd_serve(
+                argparse.Namespace(
+                    port=port,
+                    benchmark=None,
+                    no_regenerate=False,
+                    start_page=None,
+                    quiet=False,
+                )
+            )
         )
 
-    except ImportError:
-        click.echo("Error: openadapt-ml not installed.", err=True)
+    except ImportError as e:
+        click.echo(f"Error: failed to import openadapt-ml ({e}).", err=True)
+        click.echo('Install with: pip install "openadapt-ml[training]"', err=True)
         sys.exit(1)
 
 

--- a/openadapt/cli.py
+++ b/openadapt/cli.py
@@ -216,6 +216,17 @@ def train_start(
         except ImportError:
             # Older openadapt-ml without resolve_config_path; use as-is.
             pass
+
+        from pathlib import Path
+
+        if not Path(config).exists():
+            click.echo(f"Error: config not found: {config}", err=True)
+            click.echo(
+                "Upgrade openadapt-ml so bundled configs resolve, or pass "
+                "--config with a path to a training config YAML.",
+                err=True,
+            )
+            sys.exit(1)
         click.echo(f"  Config: {config}")
 
         train_main(
@@ -423,8 +434,14 @@ def serve(port: int, output: str, open: bool):
         click.echo(f"Serving from: {output}")
 
         import argparse
+        from pathlib import Path
 
-        from openadapt_ml.cloud.local import cmd_serve
+        from openadapt_ml.cloud import local as oa_local
+
+        # cmd_serve resolves the 'current' run against the module-level
+        # TRAINING_OUTPUT constant; point it at the requested directory
+        # so --output is honored.
+        oa_local.TRAINING_OUTPUT = Path(output)
 
         if open:
             import threading
@@ -434,10 +451,8 @@ def serve(port: int, output: str, open: bool):
                 1.0, webbrowser.open, args=(f"http://localhost:{port}",)
             ).start()
 
-        # cmd_serve serves the 'current' training run from the working
-        # directory's training_output; it takes an argparse Namespace.
         sys.exit(
-            cmd_serve(
+            oa_local.cmd_serve(
                 argparse.Namespace(
                     port=port,
                     benchmark=None,

--- a/openadapt/cli.py
+++ b/openadapt/cli.py
@@ -238,9 +238,7 @@ def train_start(
 
     except ImportError as e:
         click.echo(f"Error: failed to import openadapt-ml ({e}).", err=True)
-        click.echo(
-            'Install with: pip install "openadapt-ml[training]"', err=True
-        )
+        click.echo('Install with: pip install "openadapt-ml[training]"', err=True)
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary

Fixes the `OpenAdapt`-side bugs from #999 (reported by @ultimus247): `openadapt serve` and `openadapt train start` both failed with a misleading "openadapt-ml not installed" error because `cli.py` imported functions that don't exist in `openadapt-ml`, and the bare `except ImportError` blocks swallowed the real cause.

- **serve**: `serve_dashboard` → `cmd_serve(argparse.Namespace(...))` (the actual API). Browser opening now happens CLI-side since `cmd_serve` has no open flag.
- **train start**: `train_main` → `scripts.train.main(config_path=..., capture_path=..., output_dir=..., open_dashboard=...)` (the actual API and parameter names). When `--config` isn't given, selects the device-appropriate default and resolves it against the configs bundled in the openadapt-ml wheel (via the new `resolve_config_path`, with graceful fallback for older openadapt-ml).
- **error messages**: ImportError handlers now print the underlying exception and suggest `pip install "openadapt-ml[training]"`, addressing the "masked errors" complaint directly.

Companion to OpenAdaptAI/openadapt-ml#63, which fixes the internal-import, CPU-training, and config-packaging bugs on the openadapt-ml side. Full repro from the issue (`openadapt serve`, `openadapt train start --capture ...`) requires both PRs.

## Verification

- `python -m py_compile openadapt/cli.py`
- AST cross-check against the openadapt-ml#63 branch confirming `cmd_serve`, `detect_device`, `resolve_config_path`, and `scripts.train.main` all exist with the parameters cli.py now uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)