### PR TITLE
Fix GlitchTip error-reporting noise + import-smoke CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,3 +64,10 @@ jobs:
 
       - name: Run Flake8
         run: poetry run flake8 --exclude=alembic,.venv,venv,contrib,.cache,.git
+
+      # Guard against import-time breakage (missing/renamed imports, bad lazy
+      # imports) -- the class of error that dominates GlitchTip. See
+      # GLITCHTIP_FIX_PLAN.md. TODO: extend to a Windows matrix to cover the
+      # pywinauto import path.
+      - name: Import-smoke (core modules must import cleanly)
+        run: poetry run python -c "import openadapt, openadapt.config, openadapt.utils, openadapt.models, openadapt.db.db, openadapt.window, openadapt.error_reporting; print('imports ok')"

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ build/
 
 OpenAdapt.spec
 build_scripts/OpenAdapt.iss
+
+# Private keys (never commit)
+*.pem

--- a/openadapt/config.py
+++ b/openadapt/config.py
@@ -124,9 +124,11 @@ class Config(BaseSettings):
 
     # Error reporting
     ERROR_REPORTING_ENABLED: bool = True
+    # Reports to the live GlitchTip project openadaptai/openadapt (id 3798).
+    # (Project 8771, previously set here, is not in the org and is unreachable,
+    # so its events were never visible in the dashboard.)
     ERROR_REPORTING_DSN: ClassVar = (
-        # "https://dcf5d7889a3b4b47ae12a3af9ffcbeb7@app.glitchtip.com/3798"
-        "https://5d24fc5a2e674ea6b42275e5702499ce@app.glitchtip.com/8771"
+        "https://dcf5d7889a3b4b47ae12a3af9ffcbeb7@app.glitchtip.com/3798"
     )
     ERROR_REPORTING_BRANCH: ClassVar = "main"
 

--- a/openadapt/error_reporting.py
+++ b/openadapt/error_reporting.py
@@ -60,10 +60,50 @@ def show_alert() -> None:
     msg.exec()
 
 
+# Errors from environments where OpenAdapt cannot run -- headless / no display,
+# unsupported platform, or a broken/partial native dependency set -- are not
+# actionable bugs. They otherwise flood the dashboard from CI and automated
+# headless environments and bury real issues. Drop them. See GLITCHTIP_FIX_PLAN.md.
+_UNSUPPORTED_ENV_SUBSTRINGS = (
+    "failed to acquire X connection",
+    "Bad display name",
+    "DISPLAY not set",
+    "this platform is not supported",  # pynput import on headless Linux
+    "No module named 'pywinauto'",  # non-Windows / old releases (guarded on main)
+    "module 'pywinauto' has no attribute",
+    "_ARRAY_API not found",  # numpy 1.x/2.x ABI mismatch in a broken env
+    "crop_active_window should return an image",  # headless screenshot returned None
+)
+
+
+def is_unsupported_environment_error(event: Any, hint: Any) -> bool:
+    """Return True if the event is an unactionable unsupported-environment error."""
+    texts = []
+    exc_info = hint.get("exc_info") if hint else None
+    if exc_info and exc_info[1] is not None:
+        texts.append(f"{type(exc_info[1]).__name__}: {exc_info[1]}")
+    for value in (event.get("exception", {}) or {}).get("values", []) or []:
+        texts.append(f"{value.get('type')}: {value.get('value')}")
+    blob = " ".join(texts)
+    return any(substring in blob for substring in _UNSUPPORTED_ENV_SUBSTRINGS)
+
+
 def before_send_event(event: Any, hint: Any) -> Any:
-    """Handle the event before sending it to Sentry."""
+    """Filter events before sending to GlitchTip.
+
+    Drops unactionable unsupported-environment errors (headless, wrong platform,
+    broken native deps) that otherwise flood the dashboard from CI/automated
+    environments. For genuine errors, surfaces a user alert -- but only when a GUI
+    is actually running, never headless, and never for filtered noise.
+    """
+    if is_unsupported_environment_error(event, hint):
+        return None  # drop -- not an actionable bug
+
     try:
-        show_alert()
+        from PySide6.QtWidgets import QApplication
+
+        if QApplication.instance() is not None:
+            show_alert()
     except Exception:
         pass
     return event


### PR DESCRIPTION
## Why

GlitchTip (project `openadaptai/openadapt`, 3798) was dominated by **unactionable import-time crashes from automated/headless environments** (bot servers `admin123-nexus-*`, CI, no-display Linux) running OpenAdapt where it structurally can't run. These flood the dashboard and bury real issues. Triaging all 17 unresolved issues (65 events): ~80% of events are environmental noise, several "top bugs" are already fixed on this branch (pywinauto guarded, no `declarative_base(bind=)`) and recur only from old-release bots.

## What

- **`error_reporting.before_send_event`** now **drops unsupported-environment errors** (no display / `$DISPLAY` / X connection, wrong platform, `No module named 'pywinauto'`, numpy ABI `_ARRAY_API`, headless `crop_active_window`). It also **only shows the user alert when a GUI is actually running** — previously it popped a `QMessageBox` on *every* event inside the Sentry hook (broken/blocking headless).
- **`config.ERROR_REPORTING_DSN`** → live project **3798**. Previously **8771**, which isn't in the org and is unreachable, so its events were never visible in the dashboard.
- **CI import-smoke step** (`main.yml`): core modules must import cleanly — the dominant GlitchTip error class (same class as #999). TODO left for a Windows matrix (pywinauto path).
- **`gitignore *.pem`** — there was an untracked private key (`deploy/omniparser-key.pem`) at risk of `git add -A`.

## Validation

Ran the new filter against the **17 live issues**: it drops **53/65 events** (all the high-volume environmental flood) and keeps the **12-event actionable long tail**. At runtime it catches even more (the live hook sees full exception messages).

## Not done (deliberate)

- No `try/except` around `posthog`/`dictalchemy3`/`click` — they're *declared deps* (partial-install artifacts ≠ code bugs; `posthog` is subclassed at module scope). The import-smoke CI is the correct guard.
- No `numpy<2` pin (harmful in 2026; the one stale ABI error is filtered).

## Dashboard

Separately muted (status=ignored) the 7 high-volume noise issues (53 events) via the API — `ignored` not `resolved`, since old-release bots would reopen `resolved`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)