### PR TITLE
feat: mount the demonstration compiler as `openadapt flow …` and lead the CLI with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **OpenAdapt** is the **open** source software **adapt**er between Large Multimodal Models (LMMs) and traditional desktop and web GUIs.
 
-Record a GUI workflow once, then compile it into a deterministic replay, condition a model on it, or train and evaluate agents against it — all from a unified CLI. OpenAdapt is a modular meta-package: the base install is just the CLI, and each capability (capture, compiler, ML, evals, privacy) is an optional extra you add as you need it.
+Record a GUI workflow once, then compile it into a deterministic, self-healing replay that runs locally at near-zero cost — all from a unified CLI. OpenAdapt is a modular meta-package: `pip install openadapt` ships the flagship demonstration compiler (`openadapt flow …`) out of the box, and the supporting capabilities (capture, ML, evals, privacy) are optional extras you add as you need them.
 
 [Join us on Discord](https://discord.gg/yF527cQbDG) | [Documentation](https://docs.openadapt.ai) | [OpenAdapt.ai](https://openadapt.ai)
 
@@ -46,14 +46,15 @@ OpenAdapt v1.0+ uses a **modular meta-package architecture**. The main `openadap
 Install what you need:
 
 ```bash
-pip install openadapt              # Minimal CLI only
-pip install openadapt[capture]     # GUI capture/recording
-pip install openadapt[ml]          # ML training and inference
-pip install openadapt[evals]       # Benchmark evaluation
-pip install openadapt[flow]        # Demonstration compiler (record once, replay deterministically)
-pip install openadapt[privacy]     # PII/PHI scrubbing
+pip install openadapt              # CLI + demonstration compiler (openadapt flow …)
+pip install openadapt[capture]     # + GUI capture/recording
+pip install openadapt[ml]          # + ML training and inference
+pip install openadapt[evals]       # + Benchmark evaluation
+pip install openadapt[privacy]     # + PII/PHI scrubbing
 pip install openadapt[all]         # Everything
 ```
+
+The flagship demonstration compiler ships in the base install, so `openadapt flow …` works right after `pip install openadapt`.
 
 **Requirements:** Python 3.10+
 
@@ -61,28 +62,34 @@ pip install openadapt[all]         # Everything
 
 ## Quick Start
 
-### 1. Record a demonstration
+Record a workflow once, compile it into a deterministic bundle, and replay it
+locally at near-zero cost:
 
 ```bash
-openadapt capture start --name my-task
-# Perform actions in your GUI, then press Ctrl+C to stop
+openadapt flow record --url <app> --out rec     # record a workflow once
+openadapt flow compile rec --out bundle          # compile it
+openadapt flow replay bundle                     # run it, local, $0
 ```
 
-### 2. Train a model
+Inspect and gate compiled bundles before you ship them:
 
 ```bash
+openadapt flow lint bundle                       # report coverage gaps
+openadapt flow certify bundle --policy clinical-write   # enforce a safety policy
+```
+
+> `openadapt flow <verb>` is the recommended path. The standalone
+> `openadapt-flow <verb>` command keeps working and behaves identically.
+
+### Supporting commands
+
+Capture, training, and evaluation are available once you install their extras
+(`pip install openadapt[capture,ml,evals]`):
+
+```bash
+openadapt capture start --name my-task           # record raw GUI events
 openadapt train start --capture my-task --model qwen3vl-2b
-```
-
-### 3. Evaluate
-
-```bash
 openadapt eval run --checkpoint training_output/model.pt --benchmark waa
-```
-
-### 4. View recordings
-
-```bash
 openadapt capture view my-task
 ```
 
@@ -93,12 +100,20 @@ openadapt capture view my-task
 For workflows you run over and over, re-reasoning through every step with a
 large model is slow, expensive, and non-deterministic. `openadapt-flow`
 compiles a single demonstration into a script that replays **deterministically
-and locally**, with no model calls on the hot path. It ships standalone on PyPI
-(`pip install openadapt-flow`, currently v0.3.x) or as an extra:
+and locally**, with no model calls on the hot path. It ships in the base
+`openadapt` install as the flagship path, so `openadapt flow …` works out of the
+box:
 
 ```bash
-pip install openadapt[flow]
+pip install openadapt
+openadapt flow record --url <app> --out rec
+openadapt flow compile rec --out bundle --name my-flow
+openadapt flow replay bundle
 ```
+
+It also ships standalone on PyPI (`pip install openadapt-flow`, currently
+v0.3.x); the standalone `openadapt-flow <verb>` command behaves identically to
+`openadapt flow <verb>`.
 
 Each compiled step carries a template crop, an OCR label, geometry landmarks,
 and postconditions derived from what the demo changed on screen. At replay time
@@ -165,6 +180,12 @@ compiler, validation methodology, and known limits.
 ## CLI Reference
 
 ```
+openadapt flow record --url <app> --out <dir>   Record a workflow once
+openadapt flow compile <rec> --out <bundle>      Compile a recording into a bundle
+openadapt flow replay <bundle>                   Replay a bundle (local, $0)
+openadapt flow lint <bundle>                      Report a bundle's coverage gaps
+openadapt flow certify <bundle> --policy <name>   Enforce a safety policy on a bundle
+
 openadapt capture start --name <name>    Start recording
 openadapt capture stop                    Stop recording
 openadapt capture list                    List captures

--- a/openadapt/cli.py
+++ b/openadapt/cli.py
@@ -1,6 +1,12 @@
 """Unified CLI for OpenAdapt ecosystem.
 
 Usage:
+    openadapt flow record --url <app> --out rec   # record a workflow once
+    openadapt flow compile rec --out bundle        # compile it
+    openadapt flow replay bundle                    # run it, local, $0
+    openadapt flow lint bundle
+    openadapt flow certify bundle --policy clinical-write
+
     openadapt capture start --name my-task
     openadapt capture stop
     openadapt capture list
@@ -25,20 +31,201 @@ from typing import Optional
 import click
 
 
-@click.group()
+class _FlowFirstGroup(click.Group):
+    """Command group that lists ``flow`` first in ``--help``.
+
+    The demonstration compiler is the flagship, so it should lead the
+    command listing instead of sorting alphabetically behind ``capture``.
+    Everything else keeps its normal alphabetical order.
+    """
+
+    def list_commands(self, ctx):
+        commands = super().list_commands(ctx)
+        return sorted(commands, key=lambda name: (name != "flow", name))
+
+
+@click.group(cls=_FlowFirstGroup)
 @click.version_option(version="1.0.0", prog_name="openadapt")
 def main():
-    """OpenAdapt - GUI automation with ML.
+    """OpenAdapt - the demonstration compiler for GUI workflows.
 
-    Record demonstrations, train models, and evaluate agents.
+    Record a workflow once, compile it into a deterministic, self-healing
+    script, and replay it locally with no model calls on the hot path.
+    Capture, training, and evaluation remain available as supporting
+    commands.
 
     \b
     Quick Start:
-        openadapt capture start --name my-task   # Record a demonstration
-        openadapt train --capture my-task        # Train a model
-        openadapt eval --checkpoint model.pt     # Evaluate the model
+        openadapt flow record --url <app> --out rec   # record a workflow once
+        openadapt flow compile rec --out bundle        # compile it
+        openadapt flow replay bundle                    # run it, local, $0
     """
     pass
+
+
+# =============================================================================
+# Flow Commands (the demonstration compiler — flagship path)
+# =============================================================================
+
+
+def _run_flow(argv: list[str]) -> None:
+    """Delegate to the openadapt-flow CLI, preserving its exit code.
+
+    openadapt-flow exposes an argparse ``main(argv)`` entry point; each
+    ``openadapt flow <verb>`` click command reconstructs that verb's argv
+    and hands off here so behavior is identical to ``openadapt-flow <verb>``.
+    Imported lazily so ``openadapt`` (and ``openadapt flow --help``) work
+    even when openadapt-flow isn't installed.
+    """
+    try:
+        from openadapt_flow.__main__ import main as flow_main
+    except ImportError:
+        click.echo("Error: openadapt-flow not installed.", err=True)
+        click.echo(
+            'Install with: pip install "openadapt[flow]" '
+            "(or: pip install openadapt-flow)",
+            err=True,
+        )
+        sys.exit(1)
+
+    sys.exit(flow_main(argv))
+
+
+@main.group()
+def flow():
+    """Record, compile, and replay workflows (the demonstration compiler).
+
+    Record a workflow once, compile it into a deterministic vision-anchored
+    script, replay it locally at near-zero cost, and heal it on drift.
+
+    \b
+    Examples:
+        openadapt flow record --url http://localhost:8000 --out rec
+        openadapt flow compile rec --out bundle --name my-flow
+        openadapt flow replay bundle
+        openadapt flow lint bundle
+        openadapt flow certify bundle --policy clinical-write
+
+    \b
+    The standalone `openadapt-flow <verb>` command keeps working and behaves
+    identically; `openadapt flow <verb>` is the recommended path.
+    """
+    pass
+
+
+@flow.command("record")
+@click.option("--url", required=True, help="URL of the app to record against")
+@click.option("--out", required=True, help="Recording output directory")
+@click.option(
+    "--secret",
+    multiple=True,
+    metavar="FIELD",
+    help="Mark a typed field as SECRET (value never persisted). Repeatable.",
+)
+@click.option(
+    "--param",
+    multiple=True,
+    metavar="FIELD",
+    help="Record a typed field as a PARAMETER (overridable at replay). Repeatable.",
+)
+@click.option(
+    "--headless", is_flag=True, help="Run the browser headless (scripted/CI recording)"
+)
+def flow_record(url, out, secret, param, headless):
+    """Record YOUR app interactively in a headed browser."""
+    argv = ["record", "--url", url, "--out", out]
+    for value in secret:
+        argv += ["--secret", value]
+    for value in param:
+        argv += ["--param", value]
+    if headless:
+        argv.append("--headless")
+    _run_flow(argv)
+
+
+@flow.command("compile")
+@click.argument("recording")
+@click.option("--out", required=True, help="Output bundle directory")
+@click.option("--name", required=True, help="Workflow name")
+def flow_compile(recording, out, name):
+    """Compile a recording directory into a workflow bundle."""
+    _run_flow(["compile", recording, "--out", out, "--name", name])
+
+
+@flow.command("replay")
+@click.argument("bundle")
+@click.option(
+    "--url",
+    default=None,
+    help="URL of the target app (default: serve the bundled MockMed demo app)",
+)
+@click.option(
+    "--drift",
+    default=None,
+    help="Comma-separated MockMed drift modes to demo self-healing (no --url)",
+)
+@click.option("--run-dir", default=None, help="Run output directory")
+@click.option(
+    "--param",
+    multiple=True,
+    metavar="K=V",
+    help="Parameter substitution (repeatable)",
+)
+@click.option(
+    "--save-healed-to", default=None, help="Write the healed bundle to this directory"
+)
+@click.option("--headed", is_flag=True, help="Run the browser headed")
+@click.option(
+    "--record-video",
+    default=None,
+    metavar="DIR",
+    help="OPT-IN: capture a WebM video of the replay session into DIR",
+)
+def flow_replay(bundle, url, drift, run_dir, param, save_healed_to, headed, record_video):
+    """Replay a bundle (serves the bundled MockMed demo app when no --url)."""
+    argv = ["replay", bundle]
+    if url:
+        argv += ["--url", url]
+    if drift:
+        argv += ["--drift", drift]
+    if run_dir:
+        argv += ["--run-dir", run_dir]
+    for value in param:
+        argv += ["--param", value]
+    if save_healed_to:
+        argv += ["--save-healed-to", save_healed_to]
+    if headed:
+        argv.append("--headed")
+    if record_video:
+        argv += ["--record-video", record_video]
+    _run_flow(argv)
+
+
+@flow.command("lint")
+@click.argument("bundle")
+@click.option(
+    "--strict",
+    is_flag=True,
+    help="Exit nonzero on warnings too (default: only on errors)",
+)
+def flow_lint(bundle, strict):
+    """Report a bundle's coverage gaps; exits nonzero by severity."""
+    argv = ["lint", bundle]
+    if strict:
+        argv.append("--strict")
+    _run_flow(argv)
+
+
+@flow.command("certify")
+@click.argument("bundle")
+@click.option(
+    "--policy",
+    required=True,
+    help="Policy YAML path, or a built-in name (permissive, clinical-write)",
+)
+def flow_certify(bundle, policy):
+    """Enforce a safety policy on a bundle (refuse it if it fails)."""
+    _run_flow(["certify", bundle, "--policy", policy])
 
 
 # =============================================================================

--- a/openadapt/cli.py
+++ b/openadapt/cli.py
@@ -181,7 +181,9 @@ def flow_compile(recording, out, name):
     metavar="DIR",
     help="OPT-IN: capture a WebM video of the replay session into DIR",
 )
-def flow_replay(bundle, url, drift, run_dir, param, save_healed_to, headed, record_video):
+def flow_replay(
+    bundle, url, drift, run_dir, param, save_healed_to, headed, record_video
+):
     """Replay a bundle (serves the bundled MockMed demo app when no --url)."""
     argv = ["replay", bundle]
     if url:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,12 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-# Minimal base - just the CLI
+# Base install: the CLI plus the flagship demonstration compiler, so
+# `pip install openadapt` yields a working `openadapt flow` out of the box.
+# All other capabilities (capture, ml, evals, ...) remain opt-in extras.
 dependencies = [
     "click>=8.0.0",
+    "openadapt-flow>=0.3.0",
 ]
 
 [project.optional-dependencies]
@@ -50,6 +53,9 @@ retrieval = [
 privacy = [
     "openadapt-privacy>=0.1.0",
 ]
+# `flow` now ships in the base install (see `dependencies` above). This
+# extra is kept for backward compatibility so `pip install openadapt[flow]`
+# and the `all` bundle still resolve.
 flow = [
     "openadapt-flow>=0.3.0",
 ]

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -71,6 +71,129 @@ def test_version_command():
 
 
 # ---------------------------------------------------------------------------
+# Flow command (the demonstration compiler — flagship path)
+# ---------------------------------------------------------------------------
+
+FLOW_VERBS = {"record", "compile", "replay", "lint", "certify"}
+
+
+def test_top_level_help_leads_with_flow():
+    """`openadapt --help` must list flow before the other commands."""
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["--help"])
+    assert result.exit_code == 0
+    # Quick Start headline and Commands listing both lead with flow.
+    assert "openadapt flow record" in result.output
+    commands_idx = result.output.index("Commands:")
+    flow_idx = result.output.index("flow", commands_idx)
+    capture_idx = result.output.index("capture", commands_idx)
+    assert flow_idx < capture_idx, "flow should be listed before capture"
+
+
+def test_flow_help_lists_verbs():
+    """`openadapt flow --help` lists every mounted verb (no flow install
+    needed — click renders help before importing openadapt-flow)."""
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["flow", "--help"])
+    assert result.exit_code == 0, result.output
+    for verb in FLOW_VERBS:
+        assert verb in result.output, f"'{verb}' missing from `flow --help`"
+
+
+def test_flow_subcommand_help_renders():
+    """Each flow subcommand renders --help without importing flow."""
+    runner = CliRunner()
+    for verb in FLOW_VERBS:
+        result = runner.invoke(cli_main, ["flow", verb, "--help"])
+        assert result.exit_code == 0, f"`flow {verb} --help` failed: {result.output}"
+
+
+def test_flow_missing_shows_install_hint(monkeypatch):
+    """When openadapt-flow isn't installed, `openadapt flow <verb>` exits
+    nonzero with a pip install hint instead of a traceback."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def broken_import(name, *args, **kwargs):
+        if name == "openadapt_flow.__main__" or name.startswith("openadapt_flow"):
+            raise ImportError("No module named 'openadapt_flow'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", broken_import)
+    monkeypatch.delitem(sys.modules, "openadapt_flow", raising=False)
+    monkeypatch.delitem(sys.modules, "openadapt_flow.__main__", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["flow", "compile", "rec", "--out", "b", "--name", "x"])
+    assert result.exit_code != 0
+    assert "openadapt[flow]" in result.output or "openadapt-flow" in result.output
+
+
+def _require_openadapt_flow():
+    return pytest.importorskip("openadapt_flow", reason="openadapt-flow not installed")
+
+
+def test_flow_delegates_to_flow_main(monkeypatch):
+    """`openadapt flow <verb>` must reconstruct argv and call
+    openadapt_flow.__main__.main so behavior matches `openadapt-flow <verb>`."""
+    _require_openadapt_flow()
+    import openadapt_flow.__main__ as flow_main_mod
+
+    calls = []
+
+    def fake_main(argv):
+        calls.append(list(argv))
+        return 0
+
+    monkeypatch.setattr(flow_main_mod, "main", fake_main)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_main,
+        [
+            "flow",
+            "compile",
+            "my-rec",
+            "--out",
+            "my-bundle",
+            "--name",
+            "my-flow",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert calls == [["compile", "my-rec", "--out", "my-bundle", "--name", "my-flow"]]
+
+
+def test_flow_replay_argv_reconstruction(monkeypatch):
+    """Repeatable and flag options are forwarded verbatim to flow's main."""
+    _require_openadapt_flow()
+    import openadapt_flow.__main__ as flow_main_mod
+
+    calls = []
+    monkeypatch.setattr(flow_main_mod, "main", lambda argv: calls.append(list(argv)) or 0)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_main,
+        [
+            "flow",
+            "replay",
+            "bundle",
+            "--param",
+            "note=hi",
+            "--param",
+            "id=7",
+            "--headed",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        ["replay", "bundle", "--param", "note=hi", "--param", "id=7", "--headed"]
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Seam contracts with openadapt-ml
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Makes the demonstration compiler (openadapt-flow) the flagship path under the unified `openadapt` CLI.

Before: `pip install openadapt` gave `capture/train/eval/serve/doctor` but **no** `flow`; the compiler was only reachable via a separate `openadapt-flow` command, and the top-level help led with the old "GUI automation with ML" vision.

After: `openadapt flow record/compile/replay/lint/certify` works, ships out of the box, and leads the CLI.

## Changes

- **Mount `openadapt flow`** (`openadapt/cli.py`): new `@main.group() flow` with `record`, `compile`, `replay`, `lint`, `certify`. Each mirrors openadapt-flow's key options, reconstructs argv, and delegates to `openadapt_flow.__main__.main(argv)` so behavior is **identical** to `openadapt-flow <verb>`. openadapt-flow is imported **lazily** — `openadapt` and `openadapt flow --help` work even when it isn't installed; a missing install prints a `pip install "openadapt[flow]"` hint instead of a traceback. A `_FlowFirstGroup` lists `flow` first in `--help`.
- **Reframe top-level help + Quick Start** to the demonstration-compiler positioning (record once → compile → replay locally at \$0). Capture/train/eval remain as supporting commands.
- **Ship flow by default** (`pyproject.toml`): `openadapt-flow>=0.3.0` moved into base `dependencies`, so `pip install openadapt` yields a working `openadapt flow`. The `flow` extra is kept for backward compat (`openadapt[flow]`, `openadapt[all]` still resolve).
- **README**: install, Quick Start, and CLI reference now lead with `openadapt flow`; notes that standalone `openadapt-flow` still works identically.
- **Tests** (`tests/test_cli_smoke.py`): help-leads-with-flow, `flow --help` lists verbs, per-verb `--help`, missing-install hint, and argv-reconstruction/delegation contracts.

## Decision: flow ships by default (not extra-only)

`openadapt-flow` is now in the base `dependencies` (not gated behind an extra) because it is the flagship and the headline Quick Start must work immediately after `pip install openadapt`. Capture/ML/evals stay opt-in extras.

## Backward compat

The standalone `openadapt-flow <verb>` command is unchanged and behaves identically; `openadapt flow <verb>` is the new recommended path. **No change to the openadapt-flow repo was needed** — it already exposes an importable `openadapt_flow.__main__.main(argv)`.

## Verification

In a fresh Python 3.11 venv with openadapt-flow + this meta-package (`pip install -e .`) installed:
- `openadapt --help` leads with flow (Quick Start + Commands list)
- `openadapt flow --help` lists all 5 verbs; `openadapt flow compile --help` works
- `openadapt flow compile demo_rec …` → `Compiled 11 steps` — byte-identical to `openadapt-flow compile …`
- `openadapt flow replay demo_bundle` → `Replay success` (local MockMed, \$0)
- `openadapt flow lint demo_bundle` runs and reports coverage warnings
- `pytest tests/test_cli_smoke.py` — 8 passed (incl. both delegation tests), 5 skipped (openadapt-ml not in venv); ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ