### PR TITLE
fix: Discord badge 'invalid server' (switch to static badge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Downloads](https://img.shields.io/pypi/dm/openadapt.svg)](https://pypi.org/project/openadapt/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/)
-[![Discord](https://img.shields.io/discord/1084481804896374814?color=7289da&label=Discord&logo=discord&logoColor=white)](https://discord.gg/yF527cQbDG)
+[![Discord](https://img.shields.io/badge/Discord-Join%20the%20community-7289da?logo=discord&logoColor=white)](https://discord.gg/yF527cQbDG)
 
 **OpenAdapt** is the **open** source software **adapt**er between Large Multimodal Models (LMMs) and traditional desktop and web GUIs.
 


### PR DESCRIPTION
The README Discord badge used shields.io's dynamic member-count endpoint (`img.shields.io/discord/<server-id>`), which requires the Discord **Server Widget** to be enabled. It isn't, so the badge renders "invalid server". Switched to a static badge that always renders and links to the same invite (discord.gg/yF527cQbDG).

Alternative if you want the live member count back: enable **Server Settings → Widget → Enable Server Widget** in Discord, then the original dynamic badge would work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ