### PR TITLE
fix: version reads from metadata + doctor core/optional sets + pyproject description

### DIFF
--- a/openadapt/__init__.py
+++ b/openadapt/__init__.py
@@ -9,7 +9,9 @@ Install specific extras to get the functionality you need:
     pip install openadapt[all]         # Everything
 """
 
-__version__ = "1.0.0"
+# Single source of truth: derived from installed distribution metadata
+# (see openadapt/version.py) so it never drifts from pyproject.toml.
+from openadapt.version import __version__  # noqa: E402,F401
 
 # Lazy imports to avoid pulling in heavy dependencies unless needed
 

--- a/openadapt/cli.py
+++ b/openadapt/cli.py
@@ -30,6 +30,8 @@ from typing import Optional
 
 import click
 
+from openadapt.version import __version__
+
 
 class _FlowFirstGroup(click.Group):
     """Command group that lists ``flow`` first in ``--help``.
@@ -45,7 +47,7 @@ class _FlowFirstGroup(click.Group):
 
 
 @click.group(cls=_FlowFirstGroup)
-@click.version_option(version="1.0.0", prog_name="openadapt")
+@click.version_option(version=__version__, prog_name="openadapt")
 def main():
     """OpenAdapt - the demonstration compiler for GUI workflows.
 
@@ -725,36 +727,47 @@ def doctor():
     click.echo(f"\nPython: {platform.python_version()}")
     click.echo(f"Platform: {platform.system()} {platform.release()}")
 
-    # Check required packages
-    click.echo("\nCore packages:")
-    required = [
-        "openadapt_capture",
-        "openadapt_ml",
-        "openadapt_evals",
-        "openadapt_viewer",
-    ]
     from importlib.util import find_spec
 
-    for pkg in required:
+    # Core packages: installed by the base `pip install openadapt`. Only
+    # these are treated as required; a missing one is a real problem.
+    click.echo("\nCore packages (installed with `pip install openadapt`):")
+    core = [
+        "openadapt_flow",
+    ]
+    for pkg in core:
         # find_spec checks installability without executing package code
         # (importing openadapt-capture screenshots at import time, which
         # crashes headless environments)
         if find_spec(pkg) is not None:
             click.echo(f"  [OK] {pkg}")
         else:
-            click.echo(f"  [MISSING] {pkg}")
+            click.echo(
+                f"  [MISSING] {pkg} (core dependency — reinstall with "
+                f"`pip install openadapt`)"
+            )
 
-    # Check optional packages
-    click.echo("\nOptional packages:")
+    # Optional packages: opt-in extras the base install intentionally
+    # excludes. A missing extra is expected, not a failure — report how to
+    # install it rather than flagging it. Maps import name -> extra name.
+    click.echo("\nOptional packages (install with `pip install openadapt[...]`):")
     optional = [
-        "openadapt_grounding",
-        "openadapt_retrieval",
+        ("openadapt_capture", "capture"),
+        ("openadapt_ml", "ml"),
+        ("openadapt_evals", "evals"),
+        ("openadapt_viewer", "viewer"),
+        ("openadapt_grounding", "grounding"),
+        ("openadapt_retrieval", "retrieval"),
+        ("openadapt_privacy", "privacy"),
     ]
-    for pkg in optional:
+    for pkg, extra in optional:
         if find_spec(pkg) is not None:
             click.echo(f"  [OK] {pkg}")
         else:
-            click.echo(f"  [--] {pkg} (not installed)")
+            click.echo(
+                f"  [--] {pkg} (optional — install with "
+                f"`pip install openadapt[{extra}]`)"
+            )
 
     # Check GPU
     click.echo("\nGPU:")

--- a/openadapt/version.py
+++ b/openadapt/version.py
@@ -1,3 +1,19 @@
-"""Version information for the OpenAdapt meta-package."""
+"""Version information for the OpenAdapt meta-package.
 
-__version__ = "1.0.0"
+The version is read from the installed distribution metadata (populated
+from ``pyproject.toml``'s ``project.version`` at build/install time) so it
+can never drift from the package's real version. semantic-release bumps
+only ``pyproject.toml``; deriving ``__version__`` from metadata means the
+CLI and ``openadapt.__version__`` follow automatically.
+"""
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _dist_version
+
+try:
+    __version__ = _dist_version("openadapt")
+except PackageNotFoundError:  # pragma: no cover - source tree without install
+    # Running from a source checkout that was never installed. There is no
+    # metadata to read; report a clearly non-real sentinel rather than a
+    # stale hardcoded number.
+    __version__ = "0.0.0+unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "openadapt"
 version = "1.5.1"
-description = "GUI automation with ML - record, train, deploy, evaluate"
+description = "The demonstration compiler for GUI workflows: record once, compile, and replay deterministically with self-healing, locally at near-zero cost."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
@@ -10,7 +10,7 @@ authors = [
 ]
 keywords = ["gui", "automation", "ml", "rpa", "agent", "vlm", "computer-use"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -70,6 +70,58 @@ def test_version_command():
     assert result.exit_code == 0
 
 
+def test_version_flag_matches_installed_metadata():
+    """`openadapt --version` must print the real installed distribution
+    version (importlib.metadata), never a hardcoded string that can drift
+    from pyproject.toml. See openadapt/version.py."""
+    from importlib.metadata import version as dist_version
+
+    expected = dist_version("openadapt")
+
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["--version"])
+    assert result.exit_code == 0, result.output
+    assert expected in result.output
+    # And it must not be the old hardcoded value unless that is genuinely
+    # the installed version.
+    from openadapt.version import __version__
+
+    assert __version__ == expected
+
+
+def test_doctor_lists_flow_as_core_not_extras():
+    """`openadapt doctor` must treat openadapt-flow as core and the opt-in
+    extras (capture/ml/evals/viewer/...) as optional, never flagging a
+    missing extra as a failure."""
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["doctor"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+
+    core_idx = out.index("Core packages")
+    optional_idx = out.index("Optional packages")
+    assert core_idx < optional_idx
+
+    core_section = out[core_idx:optional_idx]
+    optional_section = out[optional_idx:]
+
+    # flow is core.
+    assert "openadapt_flow" in core_section
+    # The excluded-by-default extras must appear only in the optional
+    # section and must not be reported as [MISSING].
+    for extra_pkg in (
+        "openadapt_capture",
+        "openadapt_ml",
+        "openadapt_evals",
+        "openadapt_viewer",
+    ):
+        assert extra_pkg in optional_section
+        assert extra_pkg not in core_section
+    assert "[MISSING]" not in optional_section
+    # Optional section tells the user how to install extras.
+    assert "pip install openadapt[" in optional_section
+
+
 # ---------------------------------------------------------------------------
 # Flow command (the demonstration compiler — flagship path)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Release-polish fixes surfaced by external review of the `openadapt` meta-package.

### 1. `--version` was hardcoded (`1.0.0`) while the package is `1.5.1`
`openadapt/version.py` now derives `__version__` from `importlib.metadata.version("openadapt")` — the single source of truth is `pyproject.toml`'s `project.version` (which semantic-release bumps). A `0.0.0+unknown` fallback covers uninstalled source checkouts. Both `openadapt.__version__` and the CLI `--version` option consume it, so the number can never drift again. (Root cause: semantic-release only bumps `pyproject.toml`, never `version.py`/`__init__.py`/`cli.py`, so the three hardcoded copies rotted.)

### 2. Stale `pyproject.toml` metadata
- `description`: "GUI automation with ML - record, train, deploy, evaluate" → the demonstration-compiler positioning ("record once, compile, and replay deterministically with self-healing, locally at near-zero cost"), aligned with the website/README.
- Development Status classifier: `4 - Beta` → `3 - Alpha`, to reflect actual maturity rather than an aspirational claim.

### 3. `openadapt doctor` mislabeled core vs optional
The base `pip install openadapt` intentionally ships only the CLI + `openadapt-flow`. `doctor` previously treated `capture`/`ml`/`evals`/`viewer` as **required** (reporting `[MISSING]` failures) and never listed the now-core `openadapt-flow`. Fixed:
- **Core:** `openadapt_flow` only (the one non-CLI base dependency).
- **Optional:** capture, ml, evals, viewer, grounding, retrieval, privacy — reported as `[--] ... (optional — install with \`pip install openadapt[...]\`)`, never as failures.

### Tests
- `test_version_flag_matches_installed_metadata` — `openadapt --version` equals `importlib.metadata.version("openadapt")`.
- `test_doctor_lists_flow_as_core_not_extras` — flow is core; extras appear only in the optional section and are never `[MISSING]`.
- All 15 `tests/test_cli_smoke.py` tests pass.

### Verification
```
$ openadapt --version
openadapt, version 1.5.1
$ openadapt doctor
Core packages (installed with `pip install openadapt`):
  [OK] openadapt_flow
Optional packages (install with `pip install openadapt[...]`):
  [--] openadapt_viewer (optional — install with `pip install openadapt[viewer]`)
  ...
```

Scope: only `pyproject.toml`, `openadapt/version.py`, `openadapt/__init__.py`, `openadapt/cli.py` (`--version` + `doctor`), and `tests/test_cli_smoke.py`. README untouched (owned separately).

Note: a pre-existing `test_no_phantom_imports` failure (`resolve_config_path` in a stale installed `openadapt-ml`) exists on `main` and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ