### PR TITLE
fix: align launcher lifecycle metadata with beta

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 keywords = ["gui", "automation", "ml", "rpa", "agent", "vlm", "computer-use"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -89,6 +89,19 @@ def test_version_flag_matches_installed_metadata():
     assert __version__ == expected
 
 
+def test_distribution_metadata_advertises_beta_lifecycle():
+    """Published launcher metadata must match the documented Beta lifecycle."""
+    from importlib.metadata import metadata
+
+    classifiers = metadata("openadapt").get_all("Classifier") or []
+    lifecycle = [
+        classifier
+        for classifier in classifiers
+        if classifier.startswith("Development Status :: ")
+    ]
+    assert lifecycle == ["Development Status :: 4 - Beta"]
+
+
 def test_doctor_lists_flow_as_core_not_extras():
     """`openadapt doctor` must treat openadapt-flow as core and the opt-in
     extras (capture/ml/evals/viewer/...) as optional, never flagging a


### PR DESCRIPTION
## Summary
- replace the stale Alpha Trove classifier with Beta
- assert the installed distribution exposes exactly the documented Beta lifecycle

## Verification
- 20 passed, 6 skipped (optional package seam tests are absent from the isolated launcher environment)
- Ruff check and launcher-source format check
- release lock consistency check
- wheel and sdist build; wheel METADATA inspected for Development Status :: 4 - Beta

This changes launcher lifecycle metadata only. It does not change or broaden engine/backend maturity claims.