### PR TITLE
fix: publish attested launcher release artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Build release artifacts and reject workstation state
         run: |
           python -m build
+          python scripts/verify_release_artifacts.py
           tar -tzf dist/*.tar.gz > /tmp/openadapt-sdist-files.txt
           ! grep -E '/(\.env|\.cache/|[^/]+\.db$|output\.png$|\.claude/|\.worktrees/)' /tmp/openadapt-sdist-files.txt
           unzip -l dist/*.whl > /tmp/openadapt-wheel-files.txt

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -1,74 +1,182 @@
 name: Release and PyPI Publish
 
+# Release credentials are deliberately separated from build and publication:
+# - release: may update protected main and create the tag/release;
+# - build-and-attest: can only read source and issue artifact attestations;
+# - publish-pypi: receives only the project-scoped PyPI token;
+# - publish-github: may only attach assets to the GitHub Release.
+#
+# Every third-party action is pinned to a full commit SHA. Dependabot should
+# propose reviewed SHA updates rather than following mutable tags.
+
 on:
   push:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
-  release-and-publish:
+  release:
     runs-on: ubuntu-latest
-    concurrency: release
     permissions:
-      id-token: write
       contents: write
+    outputs:
+      released: ${{ steps.release.outputs.released || 'false' }}
+      tag: ${{ steps.release.outputs.tag || '' }}
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           token: ${{ secrets.ADMIN_TOKEN }}
 
-      - name: Check if should skip
+      - name: Skip the generated release commit
         id: check_skip
         run: |
           if [ "$(git log -1 --pretty=format:'%an')" = "OpenAdapt Bot" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Set up Python
-        if: steps.check_skip.outputs.skip != 'true'
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.10'
-
-      - name: Install dependencies
-        if: steps.check_skip.outputs.skip != 'true'
-        run: pip install poetry
 
       - name: Python Semantic Release
         if: steps.check_skip.outputs.skip != 'true'
         id: release
-        uses: python-semantic-release/python-semantic-release@v10.5.3
+        uses: python-semantic-release/python-semantic-release@39dd2052f2ce8282a5d932c31d58a2ca06d2550e # v10.6.1
         with:
           github_token: ${{ secrets.ADMIN_TOKEN }}
           git_committer_name: "OpenAdapt Bot"
           git_committer_email: "bot@openadapt.ai"
 
-      - name: Build and publish to PyPI
-        if: steps.check_skip.outputs.skip != 'true' && steps.release.outputs.released == 'true'
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          # PSR's build_command updates and stages uv.lock in the generated
-          # release commit. Verify that exact commit before building it.
-          git pull --ff-only
-          python scripts/verify_release_lock.py
-          poetry config pypi-token.pypi $PYPI_TOKEN
-          poetry build
-          poetry publish --no-interaction --skip-existing
+  build-and-attest:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
 
-      # Releases in openadapt-ml failed silently for 3 months (Mar-Jun
-      # 2026) while PyPI went stale; see issue #999. Fail loudly instead.
-      - name: File issue on release failure
-        if: failure()
+    steps:
+      - name: Checkout released tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.29"
+          enable-cache: false
+
+      - name: Build exact release artifacts
+        run: |
+          python scripts/verify_release_lock.py
+          uv build --wheel --sdist
+          python scripts/verify_release_artifacts.py
+
+      - name: Attest release artifacts
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        with:
+          subject-path: |
+            dist/*.whl
+            dist/*.tar.gz
+
+      - name: Transfer release artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-dists-${{ needs.release.outputs.tag }}
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-pypi:
+    needs: [release, build-and-attest]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Download attested release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-dists-${{ needs.release.outputs.tag }}
+          path: dist/
+
+      # The launcher currently uses a project-scoped API token. GitHub's
+      # repository attestation above remains verifiable; PyPI-native PEP 740
+      # attestations require a separate Trusted Publisher settings migration.
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true
+          attestations: false
+
+  publish-github:
+    needs: [release, build-and-attest]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout released tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+
+      - name: Download attested release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-dists-${{ needs.release.outputs.tag }}
+          path: dist/
+
+      - name: Attach artifacts to GitHub Release
+        uses: python-semantic-release/publish-action@5a5718ce47b892ef699f2972dae122297771d641 # v10.6.1
+        with:
+          github_token: ${{ github.token }}
+          tag: ${{ needs.release.outputs.tag }}
+
+  report-release-failure:
+    needs: [release, build-and-attest, publish-pypi, publish-github]
+    if: >-
+      ${{ always() &&
+          (needs.release.result == 'failure' ||
+           needs.build-and-attest.result == 'failure' ||
+           needs.publish-pypi.result == 'failure' ||
+           needs.publish-github.result == 'failure') }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: File or update release failure issue
         env:
-          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_RESULT: ${{ needs.release.result }}
+          BUILD_RESULT: ${{ needs.build-and-attest.result }}
+          PYPI_RESULT: ${{ needs.publish-pypi.result }}
+          GITHUB_RESULT: ${{ needs.publish-github.result }}
         run: |
           TITLE="Release workflow failed on main"
           BODY="The release workflow failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-          Until this is fixed, merged fix/feat commits are NOT being published to PyPI, and users install stale versions."
+          release=${RELEASE_RESULT}, build-and-attest=${BUILD_RESULT}, publish-pypi=${PYPI_RESULT}, publish-github=${GITHUB_RESULT}.
+
+          Until this is fixed, do not assume that the Git tag, PyPI files, GitHub assets, and attestations are mutually complete."
           EXISTING=$(gh issue list --repo "${{ github.repository }}" --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" --repo "${{ github.repository }}" --body "$BODY"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ Repository = "https://github.com/OpenAdaptAI/openadapt"
 "Bug Tracker" = "https://github.com/OpenAdaptAI/openadapt/issues"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.31.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository-local release verification scripts."""

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,0 @@
-"""Repository-local release verification scripts."""

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -1,0 +1,142 @@
+"""Verify that ``dist/`` contains exactly the release wheel and source archive."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import tarfile
+import zipfile
+from email import policy
+from email.message import Message
+from email.parser import BytesParser
+from pathlib import Path
+
+# Direct execution adds scripts/, rather than its parent, to ``sys.path``.
+try:
+    from scripts.verify_release_lock import _project_identity
+except ModuleNotFoundError:
+    from verify_release_lock import _project_identity
+
+ROOT = Path(__file__).resolve().parents[1]
+BETA_CLASSIFIER = "Development Status :: 4 - Beta"
+
+
+def _distribution_metadata(raw: bytes, source: str) -> Message:
+    metadata = BytesParser(policy=policy.default).parsebytes(raw)
+    for field in ("Name", "Version", "Summary", "Requires-Python"):
+        if not metadata.get(field):
+            raise ValueError(f"{source} metadata is missing {field}")
+    return metadata
+
+
+def _wheel_metadata(path: Path) -> Message:
+    with zipfile.ZipFile(path) as archive:
+        members = [
+            name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+        ]
+        if len(members) != 1:
+            raise ValueError(f"{path.name} must contain exactly one METADATA file")
+        return _distribution_metadata(archive.read(members[0]), path.name)
+
+
+def _sdist_metadata(path: Path) -> Message:
+    with tarfile.open(path, mode="r:gz") as archive:
+        members = [
+            member
+            for member in archive.getmembers()
+            if member.name.endswith("/PKG-INFO")
+        ]
+        if len(members) != 1 or not members[0].isfile():
+            raise ValueError(f"{path.name} must contain exactly one PKG-INFO file")
+        stream = archive.extractfile(members[0])
+        if stream is None:
+            raise ValueError(f"cannot read PKG-INFO from {path.name}")
+        return _distribution_metadata(stream.read(), path.name)
+
+
+def _lifecycle(metadata: Message) -> list[str]:
+    return [
+        value
+        for value in metadata.get_all("Classifier", [])
+        if value.startswith("Development Status :: ")
+    ]
+
+
+def verify_release_artifacts(
+    dist_dir: Path,
+    root: Path = ROOT,
+) -> tuple[Path, Path]:
+    """Return the verified ``(wheel, sdist)`` paths or raise ``ValueError``."""
+    package_name, project_version = _project_identity(root)
+    wheel_name = re.sub(r"[-_.]+", "_", package_name)
+    sdist_name = re.sub(r"[-_.]+", "-", package_name)
+
+    wheels = sorted(dist_dir.glob(f"{wheel_name}-{project_version}-*.whl"))
+    sdist = dist_dir / f"{sdist_name}-{project_version}.tar.gz"
+    if len(wheels) != 1 or not sdist.is_file():
+        raise ValueError(
+            f"expected one {wheel_name}-{project_version}-*.whl and {sdist.name}"
+        )
+
+    expected = {wheels[0], sdist}
+    marker = dist_dir / ".gitignore"
+    allowed = set(expected)
+    if marker.is_file():
+        if marker.read_bytes() not in {b"", b"\n", b"*"}:
+            raise ValueError("dist/.gitignore contains unexpected data")
+        allowed.add(marker)
+    actual = {path for path in dist_dir.iterdir() if path.is_file()}
+    if actual != allowed:
+        unexpected = ", ".join(sorted(path.name for path in actual - allowed))
+        missing = ", ".join(sorted(path.name for path in allowed - actual))
+        raise ValueError(
+            f"release artifact set mismatch; unexpected=[{unexpected}], missing=[{missing}]"
+        )
+
+    wheel_metadata = _wheel_metadata(wheels[0])
+    sdist_metadata = _sdist_metadata(sdist)
+    for source, metadata in (
+        (wheels[0].name, wheel_metadata),
+        (sdist.name, sdist_metadata),
+    ):
+        if metadata["Name"].lower() != package_name.lower():
+            raise ValueError(f"{source} package name does not match {package_name}")
+        if metadata["Version"] != project_version:
+            raise ValueError(f"{source} version does not match {project_version}")
+        if _lifecycle(metadata) != [BETA_CLASSIFIER]:
+            raise ValueError(f"{source} does not declare the Beta launcher lifecycle")
+
+    comparable_fields = ("Name", "Version", "Summary", "Requires-Python")
+    if any(
+        wheel_metadata[field] != sdist_metadata[field] for field in comparable_fields
+    ):
+        raise ValueError("wheel and source distribution metadata disagree")
+
+    return wheels[0], sdist
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dist_dir", nargs="?", type=Path, default=ROOT / "dist")
+    args = parser.parse_args()
+    try:
+        wheel, sdist = verify_release_artifacts(args.dist_dir)
+    except (OSError, ValueError, tarfile.TarError, zipfile.BadZipFile) as exc:
+        parser.exit(1, f"{exc}\n")
+
+    for artifact in (wheel, sdist):
+        print(f"{_sha256(artifact)}  {artifact.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -12,14 +12,32 @@ from email.message import Message
 from email.parser import BytesParser
 from pathlib import Path
 
-# Direct execution adds scripts/, rather than its parent, to ``sys.path``.
-try:
-    from scripts.verify_release_lock import _project_identity
-except ModuleNotFoundError:
-    from verify_release_lock import _project_identity
-
 ROOT = Path(__file__).resolve().parents[1]
 BETA_CLASSIFIER = "Development Status :: 4 - Beta"
+
+
+def _quoted_table_value(text: str, table: str, key: str) -> str:
+    current_table = ""
+    assignment = re.compile(rf'^{re.escape(key)}\s*=\s*"([^"]+)"\s*$')
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            current_table = line
+            continue
+        if current_table != f"[{table}]":
+            continue
+        match = assignment.match(line)
+        if match:
+            return match.group(1)
+    raise ValueError(f"missing quoted {key!r} in [{table}]")
+
+
+def _project_identity(root: Path) -> tuple[str, str]:
+    project_text = (root / "pyproject.toml").read_text(encoding="utf-8")
+    return (
+        _quoted_table_value(project_text, "project", "name"),
+        _quoted_table_value(project_text, "project", "version"),
+    )
 
 
 def _distribution_metadata(raw: bytes, source: str) -> Message:

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.verify_release_artifacts import verify_release_artifacts
+
+
+def _metadata(version: str) -> bytes:
+    return (
+        "Metadata-Version: 2.4\n"
+        "Name: openadapt\n"
+        f"Version: {version}\n"
+        "Summary: Beta launcher\n"
+        "Requires-Python: >=3.10\n"
+        "Classifier: Development Status :: 4 - Beta\n\n"
+    ).encode()
+
+
+def _release_tree(tmp_path: Path, artifact_version: str = "2.0.0") -> tuple[Path, Path]:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "openadapt"\nversion = "2.0.0"\n',
+        encoding="utf-8",
+    )
+    dist = tmp_path / "dist"
+    dist.mkdir()
+
+    wheel = dist / "openadapt-2.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, mode="w") as archive:
+        archive.writestr(
+            "openadapt-2.0.0.dist-info/METADATA", _metadata(artifact_version)
+        )
+
+    sdist = dist / "openadapt-2.0.0.tar.gz"
+    raw = _metadata(artifact_version)
+    info = tarfile.TarInfo("openadapt-2.0.0/PKG-INFO")
+    info.size = len(raw)
+    with tarfile.open(sdist, mode="w:gz") as archive:
+        archive.addfile(info, io.BytesIO(raw))
+    return dist, wheel
+
+
+def test_release_artifacts_accept_exact_matching_pair(tmp_path: Path):
+    dist, wheel = _release_tree(tmp_path)
+
+    actual_wheel, actual_sdist = verify_release_artifacts(dist, root=tmp_path)
+
+    assert actual_wheel == wheel
+    assert actual_sdist == dist / "openadapt-2.0.0.tar.gz"
+
+
+def test_release_artifacts_accept_uv_ignore_marker(tmp_path: Path):
+    dist, _ = _release_tree(tmp_path)
+    (dist / ".gitignore").write_text("*", encoding="utf-8")
+
+    verify_release_artifacts(dist, root=tmp_path)
+
+
+def test_release_artifacts_reject_unexpected_files(tmp_path: Path):
+    dist, _ = _release_tree(tmp_path)
+    (dist / "stale.whl").write_bytes(b"stale")
+
+    with pytest.raises(ValueError, match="unexpected=\\[stale.whl\\]"):
+        verify_release_artifacts(dist, root=tmp_path)
+
+
+def test_release_artifacts_reject_metadata_version_drift(tmp_path: Path):
+    dist, _ = _release_tree(tmp_path, artifact_version="1.9.9")
+
+    with pytest.raises(ValueError, match="version does not match 2.0.0"):
+        verify_release_artifacts(dist, root=tmp_path)

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import io
+import runpy
 import tarfile
 import zipfile
 from pathlib import Path
 
 import pytest
 
-from scripts.verify_release_artifacts import verify_release_artifacts
+ROOT = Path(__file__).resolve().parents[1]
+verify_release_artifacts = runpy.run_path(
+    str(ROOT / "scripts/verify_release_artifacts.py")
+)["verify_release_artifacts"]
 
 
 def _metadata(version: str) -> bytes:

--- a/tests/test_release_lock.py
+++ b/tests/test_release_lock.py
@@ -1,7 +1,10 @@
+import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 VERIFIER = ROOT / "scripts/verify_release_lock.py"
@@ -76,7 +79,63 @@ def test_release_workflow_syncs_and_verifies_lock_before_build():
     stage_index = metadata.index("git add uv.lock")
     assert sync_index < stage_index
 
-    pull_index = workflow.index("git pull --ff-only")
     verify_index = workflow.index("python scripts/verify_release_lock.py")
-    build_index = workflow.index("poetry build")
-    assert pull_index < verify_index < build_index
+    build_index = workflow.index("uv build --wheel --sdist")
+    artifact_index = workflow.index("python scripts/verify_release_artifacts.py")
+    attest_index = workflow.index("- name: Attest release artifacts")
+    transfer_index = workflow.index("- name: Transfer release artifacts")
+    assert verify_index < build_index < artifact_index < attest_index < transfer_index
+
+
+def test_release_workflow_pins_actions_and_separates_permissions():
+    workflow_path = ROOT / ".github/workflows/release-and-publish.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    document = yaml.safe_load(workflow)
+    metadata = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    action_refs = re.findall(r"(?m)^\s*uses:\s+\S+@([^\s#]+)", workflow)
+    assert action_refs
+    assert all(re.fullmatch(r"[0-9a-f]{40}", ref) for ref in action_refs)
+    assert 'requires = ["hatchling==1.31.0"]' in metadata
+
+    assert document["permissions"] == {"contents": "read"}
+    jobs = document["jobs"]
+    assert jobs["release"]["permissions"] == {"contents": "write"}
+    assert jobs["build-and-attest"]["permissions"] == {
+        "contents": "read",
+        "id-token": "write",
+        "attestations": "write",
+    }
+    assert jobs["publish-pypi"]["permissions"] == {"contents": "read"}
+    assert jobs["publish-github"]["permissions"] == {"contents": "write"}
+    assert jobs["report-release-failure"]["permissions"] == {"issues": "write"}
+
+
+def test_release_workflow_publishes_the_attested_bytes_to_both_destinations():
+    workflow_path = ROOT / ".github/workflows/release-and-publish.yml"
+    document = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    jobs = document["jobs"]
+
+    build_steps = jobs["build-and-attest"]["steps"]
+    attest = next(
+        step for step in build_steps if step["name"] == "Attest release artifacts"
+    )
+    transfer = next(
+        step for step in build_steps if step["name"] == "Transfer release artifacts"
+    )
+    assert attest["with"]["subject-path"].splitlines() == [
+        "dist/*.whl",
+        "dist/*.tar.gz",
+    ]
+    assert transfer["with"]["path"].splitlines() == [
+        "dist/*.whl",
+        "dist/*.tar.gz",
+    ]
+    assert transfer["with"]["if-no-files-found"] == "error"
+
+    pypi_steps = jobs["publish-pypi"]["steps"]
+    github_steps = jobs["publish-github"]["steps"]
+    assert pypi_steps[0]["with"]["name"] == transfer["with"]["name"]
+    assert github_steps[1]["with"]["name"] == transfer["with"]["name"]
+    assert pypi_steps[1]["with"]["attestations"] is False
+    assert github_steps[2]["with"]["tag"] == "${{ needs.release.outputs.tag }}"


### PR DESCRIPTION
## Summary
- separate versioning, build/attestation, PyPI publication, GitHub asset upload, and failure reporting into least-privilege jobs
- pin every release action and the Hatchling build backend to immutable versions
- verify the exact wheel/sdist set and metadata before attestation or publication
- attach both distributions to the GitHub Release and generate GitHub SLSA provenance for their exact hashes
- report failures from any release stage using an issue-only token

## Verification
- 26 passed, 6 skipped locally; remote matrix installs optional seam packages
- Ruff check and format check pass
- actionlint 1.7.12 passes; downloaded binary matched its published SHA-256
- no-push Python 3.12 build and artifact verifier pass
- release lock remains synchronized

## Boundary
The existing project-scoped PyPI API token remains the publisher credential, so PyPI-native PEP 740 attestations stay disabled. The same wheel/sdist bytes receive GitHub SLSA provenance before transfer to both destinations; migrating repository settings to PyPI Trusted Publishing is a separate external change.