### PR TITLE
fix: publish release assets from named branch

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -133,10 +133,15 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout released tag
+      # The publish action resolves the configured release group from the
+      # current branch. Keep this checkout attached to main; the exact release
+      # is still selected by `tag` and the exact bytes come from the attested
+      # artifact transfer below.
+      - name: Checkout release branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ needs.release.outputs.tag }}
+          ref: main
+          fetch-depth: 0
 
       - name: Download attested release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/tests/test_release_lock.py
+++ b/tests/test_release_lock.py
@@ -139,3 +139,7 @@ def test_release_workflow_publishes_the_attested_bytes_to_both_destinations():
     assert github_steps[1]["with"]["name"] == transfer["with"]["name"]
     assert pypi_steps[1]["with"]["attestations"] is False
     assert github_steps[2]["with"]["tag"] == "${{ needs.release.outputs.tag }}"
+
+    checkout = github_steps[0]
+    assert checkout["name"] == "Checkout release branch"
+    assert checkout["with"] == {"ref": "main", "fetch-depth": 0}


### PR DESCRIPTION
## Summary
- keep immutable-tag checkout for build and attestation
- run the semantic-release publisher from named main while selecting the exact release tag
- assert the branch/tag/artifact-transfer contract in tests

## Incident recovery
The first v1.6.2 run published to PyPI and generated GitHub attestations, but its detached-tag publisher could not resolve a release group. The exact attested workflow artifacts have been attached manually to v1.6.2.

## Verification
- uv run pytest -q: 31 passed, 1 skipped
- uv run ruff check openadapt tests scripts
- actionlint 1.7.12
- git diff --check