### PR TITLE
docs: recognize active openadapt-agent v2 bridge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,14 +13,17 @@ replay, repair, policy, and backend work belongs there.
 |-----------|--------------|--------------------|
 | **Beta product** | `OpenAdapt`, `openadapt-flow` | Launcher here; engine in `openadapt-flow` |
 | **Experimental support** | `openadapt-capture`, `openadapt-privacy`, `openadapt-desktop` | Native capture, scrubbing, and authoring surfaces |
+| **Agent integration** | `openadapt-agent` | MCP and Agent Skills bridge over governed Flow bundles |
 | **Research** | `openadapt-ml`, `openadapt-evals`, `openadapt-grounding`, `openadapt-retrieval` | GUI-agent research and evaluation, not the product runtime |
-| **Deprecated/history** | `openadapt-agent`, `legacy/` | Migration fixes only; no new features |
+| **Deprecated/history** | `legacy/`, pre-v2 `openadapt-agent` | Migration fixes only; no new features |
 
 ## Where to Contribute
 
 - **This repository**: launcher packaging, unified CLI compatibility, and CI.
 - **`openadapt-flow`**: compiler, replay, verification, governed repair, and
   backend implementation.
+- **`openadapt-agent`**: agent-facing MCP and Agent Skills integration over
+  governed Flow bundles.
 - **Other repositories**: open issues only when their stated lifecycle and
   contribution guide match the proposed work.
 

--- a/README.md
+++ b/README.md
@@ -171,8 +171,11 @@ runs in CI with no OS permissions. Desktop, Citrix, and RDP backends are
 adapters in progress, not yet production paths: Windows UI Automation is
 Experimental, and RDP/Citrix-style pixel-only automation is Research — we are
 seeking design partners to validate them on real deployments.
-Compiled workflows can also be emitted as Agent Skills or MCP
-servers so other agents can invoke them.
+Compiled workflows can also be emitted as Agent Skills or MCP servers so other
+agents can invoke them. The
+[`openadapt-agent`](https://github.com/OpenAdaptAI/openadapt-agent) v2 bridge
+serves governed Flow bundles over MCP and emits Agent Skills without becoming
+a second execution runtime.
 
 In one field test against a computer-use agent on a real third-party EMR
 (OpenEMR's public demo), compiled replay matched the agent's success (20/20
@@ -199,6 +202,7 @@ blanket production-readiness claim.
 |---------|------|----------|------------|
 | `openadapt` | Installer + unified CLI (`openadapt flow ...`) | **Beta** | This repo |
 | `openadapt-flow` | Compiler + governed runtime | **Beta**; browser path proven, Windows UI Automation experimental, remote-display (RDP/Citrix) research | [openadapt-flow](https://github.com/OpenAdaptAI/openadapt-flow) |
+| `openadapt-agent` | MCP + Agent Skills bridge over governed Flow bundles | Active v2 integration surface | [openadapt-agent](https://github.com/OpenAdaptAI/openadapt-agent) |
 | `openadapt-capture` | Optional native recorder | **Experimental** | [openadapt-capture](https://github.com/OpenAdaptAI/openadapt-capture) |
 | `openadapt-privacy` | Optional PII/PHI scrubbing | **Experimental** | [openadapt-privacy](https://github.com/OpenAdaptAI/openadapt-privacy) |
 
@@ -290,9 +294,10 @@ runtime conditioning.
 
 - **New automation work:** install `openadapt` and use `openadapt flow ...`; make
   engine changes in `openadapt-flow`.
-- **`openadapt-agent`: Deprecated.** Do not build new integrations on it. Its
-  execution responsibilities have moved to the governed runtime in
-  `openadapt-flow`.
+- **`openadapt-agent` v2: Active bridge.** Build agent-facing integrations on
+  its MCP and Agent Skills surface. Governed execution remains in
+  `openadapt-flow`; the pre-v2 model-driven execution wrapper is the deprecated
+  component.
 - **Pre-1.0 monolith: Historical.** Version 0.46.0 and its source remain
   available for existing users, but receive no feature development.
 


### PR DESCRIPTION
## What changed

- recognizes `openadapt-agent` v2 as the active MCP and Agent Skills bridge
- keeps governed execution in `openadapt-flow` rather than presenting a second runtime
- narrows deprecation to the removed pre-v2 model-driven execution wrapper
- routes agent-integration contributions to the active v2 repository

## Why

The flagship README still deprecated the entire repository after
`openadapt-agent` PR #2 repurposed it into an agent-facing Flow bridge. The
old wording sent new integrations away from the implementation that now owns
them.

## Validation

- `uv run pytest tests -q` — 31 passed, 1 skipped
- `git diff --check` — passed
