### PR TITLE
docs: bind sandbox notices to packaging fix

### DIFF
--- a/docs/reference-sandbox-source-and-notices.json
+++ b/docs/reference-sandbox-source-and-notices.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "published_for": {
     "service": "OpenAdapt reference sandbox",
-    "cloud_release_sha256": "2a8a1dfb3b468ea99a02379d7f0a0db0f33c4df0127de71f3d012d3a21167f55",
+    "cloud_release_sha256": "f3c24132c396b398433fca544da2b13bd46386d771558e3274d3e9744ce8a045",
     "target_manifest_sha256": "032e05a5364beddce58c4752d9889fa7a2d2c41f0555285d4e416bae75d96c88"
   },
   "scope": "Source identities and required notices for the unmodified third-party applications served in isolated synthetic reference sandboxes.",

--- a/docs/reference-sandbox-source-and-notices.json
+++ b/docs/reference-sandbox-source-and-notices.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "published_for": {
     "service": "OpenAdapt reference sandbox",
-    "cloud_release_sha256": "44b023311abd1808247c361e32f8901a42b73516268c6f0f21797b97cf61c564",
+    "cloud_release_sha256": "2a8a1dfb3b468ea99a02379d7f0a0db0f33c4df0127de71f3d012d3a21167f55",
     "target_manifest_sha256": "032e05a5364beddce58c4752d9889fa7a2d2c41f0555285d4e416bae75d96c88"
   },
   "scope": "Source identities and required notices for the unmodified third-party applications served in isolated synthetic reference sandboxes.",


### PR DESCRIPTION
## Summary

Bind the public reference-sandbox source-and-notices manifest to the corrected Cloud provider release digest.

The Cloud fix changes only remote control-image source-directory resolution so the VM input files packaged under `/root/openadapt_runner` are mounted from their real location. It does not change any upstream application identity, source commit, modification status, license, image digest, or target-manifest digest.

## Boundary

- One JSON digest update; no package/runtime code.
- No copied GPL/AGPL source.
- Target manifest remains `032e05a5364beddce58c4752d9889fa7a2d2c41f0555285d4e416bae75d96c88`.
- Corrected Cloud release is `2a8a1dfb3b468ea99a02379d7f0a0db0f33c4df0127de71f3d012d3a21167f55`.

The prior provider attempt stopped before creating any reference VM, and the public sandbox remains disabled.
