### PR TITLE
fix: forward all engine options through `openadapt flow record`

### DIFF
--- a/openadapt/cli.py
+++ b/openadapt/cli.py
@@ -47,6 +47,10 @@ class _FlowFirstGroup(click.Group):
 
 
 _FLOW_PASSTHROUGH_COMMANDS = {
+    "record": (
+        "Record YOUR app (web browser by default; --backend "
+        "windows/macos/linux/rdp for native desktop capture)."
+    ),
     "induce": "Induce a parameterized program from multiple recordings.",
     "run": "Run a bundle under a fail-closed deployment configuration.",
     "resume": "Resume a durably paused run from its verified checkpoint.",
@@ -224,34 +228,13 @@ def connect(pairing, uri, host, device_name, destination_kind, trusted_host):
     _run_flow(argv)
 
 
-@flow.command("record")
-@click.option("--url", required=True, help="URL of the app to record against")
-@click.option("--out", required=True, help="Recording output directory")
-@click.option(
-    "--secret",
-    multiple=True,
-    metavar="FIELD",
-    help="Mark a typed field as SECRET (value never persisted). Repeatable.",
-)
-@click.option(
-    "--param",
-    multiple=True,
-    metavar="FIELD",
-    help="Record a typed field as a PARAMETER (overridable at replay). Repeatable.",
-)
-@click.option(
-    "--headless", is_flag=True, help="Run the browser headless (scripted/CI recording)"
-)
-def flow_record(url, out, secret, param, headless):
-    """Record YOUR app interactively in a headed browser."""
-    argv = ["record", "--url", url, "--out", out]
-    for value in secret:
-        argv += ["--secret", value]
-    for value in param:
-        argv += ["--param", value]
-    if headless:
-        argv.append("--headless")
-    _run_flow(argv)
+# NOTE: `record` is intentionally NOT wrapped with explicit click options.
+# It delegates through _FlowPassthroughGroup so every engine option
+# (--backend web/windows/macos/linux/rdp, --agent-url, --macos-app,
+# --linux-app, --rdp-host, --task, ...) forwards verbatim and new engine
+# options never need a launcher release. An earlier explicit wrapper here
+# hid --backend (and required --url, which the engine only requires for
+# --backend web).
 
 
 @flow.command("demo-record")

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -149,6 +149,12 @@ def test_doctor_lists_flow_as_core_not_extras():
 
 FLOW_VERBS = {"demo-record", "record", "compile", "replay", "lint", "certify"}
 
+# Verbs wrapped with explicit click options (local --help, no engine import).
+# `record` is intentionally absent: it delegates through the passthrough
+# group so every engine option (--backend, --agent-url, ...) forwards
+# verbatim — its --help comes from the engine itself.
+FLOW_WRAPPED_VERBS = FLOW_VERBS - {"record"}
+
 
 def test_launcher_requires_pairing_enabled_flow_release():
     """Every install route must resolve an engine with transactional pairing."""
@@ -188,11 +194,100 @@ def test_flow_help_lists_verbs():
 
 
 def test_flow_subcommand_help_renders():
-    """Each flow subcommand renders --help without importing flow."""
+    """Each explicitly wrapped flow subcommand renders --help without
+    importing flow."""
     runner = CliRunner()
-    for verb in FLOW_VERBS:
+    for verb in FLOW_WRAPPED_VERBS:
         result = runner.invoke(cli_main, ["flow", verb, "--help"])
         assert result.exit_code == 0, f"`flow {verb} --help` failed: {result.output}"
+
+
+def test_flow_record_help_is_engine_help():
+    """`openadapt flow record --help` must render the ENGINE's help (with
+    --backend and the desktop-backend options), not a launcher wrapper
+    that hides them."""
+    _require_openadapt_flow()
+    result = CliRunner().invoke(cli_main, ["flow", "record", "--help"])
+    assert result.exit_code == 0, result.output
+    for option in ("--backend", "--agent-url", "--task"):
+        assert option in result.output, (
+            f"{option} missing from `flow record --help`; the launcher is "
+            "hiding engine options again"
+        )
+
+
+def test_flow_record_forwards_backend_options(monkeypatch):
+    """Regression (launcher <=1.7.0): the explicit record wrapper rejected
+    `--backend windows` with "No such option". record must forward every
+    engine option verbatim, like run/push."""
+    captured = {}
+    monkeypatch.setattr(
+        "openadapt.cli._run_flow", lambda argv: captured.update(argv=list(argv))
+    )
+    result = CliRunner().invoke(
+        cli_main,
+        [
+            "flow",
+            "record",
+            "--backend",
+            "windows",
+            "--agent-url",
+            "http://localhost:5001",
+            "--out",
+            "rec",
+            "--task",
+            "triage note",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["argv"] == [
+        "record",
+        "--backend",
+        "windows",
+        "--agent-url",
+        "http://localhost:5001",
+        "--out",
+        "rec",
+        "--task",
+        "triage note",
+    ]
+
+
+def test_flow_record_web_invocation_forwards_verbatim(monkeypatch):
+    """The pre-existing web invocation shape keeps working unchanged."""
+    captured = {}
+    monkeypatch.setattr(
+        "openadapt.cli._run_flow", lambda argv: captured.update(argv=list(argv))
+    )
+    result = CliRunner().invoke(
+        cli_main,
+        [
+            "flow",
+            "record",
+            "--url",
+            "http://localhost:3000",
+            "--out",
+            "rec",
+            "--secret",
+            "password",
+            "--param",
+            "note",
+            "--headless",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["argv"] == [
+        "record",
+        "--url",
+        "http://localhost:3000",
+        "--out",
+        "rec",
+        "--secret",
+        "password",
+        "--param",
+        "note",
+        "--headless",
+    ]
 
 
 def test_flow_missing_shows_install_hint(monkeypatch):


### PR DESCRIPTION
## Problem

The launcher's click wrapper for `openadapt flow record` enumerated only the web-era options, so `openadapt flow record --backend windows` failed with `No such option: --backend` even though the engine (`openadapt-flow` >= 1.17, verified against 1.17.2) supports `--backend {web,windows,macos,linux,rdp}`. Sibling verbs (`run`, `push`, `teach`, ...) already forward generically and were unaffected.

Engine `record` options the wrapper hid:

- `--backend {web,windows,macos,linux,rdp}`
- `--agent-url` (windows / WAA agent)
- `--macos-app`, `--macos-window-title`
- `--linux-app`, `--linux-window-title`, `--linux-allow-physical-input`
- `--rdp-host`
- `--task`

The wrapper also forced `--url`, which the engine only requires for `--backend web` — desktop backends were unreachable even in principle.

## Fix

Convert `record` to the existing `_FlowPassthroughGroup` generic delegation (same mechanism as `run`/`push`): all arguments forward verbatim to `openadapt-flow record`, `openadapt flow record --help` renders the engine's real help, and future engine options never need a launcher release. Existing web invocations (`--url/--out/--secret/--param/--headless`) forward byte-for-byte unchanged (regression-tested).

Behavioral deltas, all intentional:
- `--backend` and the desktop-backend options above now work.
- Missing/invalid options are diagnosed by the engine's parser (which knows `--url` is web-only) instead of a stale launcher copy.
- `record` still appears in `openadapt flow --help` with an updated one-line summary.

## Verification

- Fresh venv, `pip install -e ".[dev]"` with real `openadapt-flow` 1.17.2 from PyPI: `openadapt flow record --backend windows --url x --out y` now reaches the engine's parser and enters the desktop-record path (halts only on the missing optional `openadapt-capture` extra, as standalone `openadapt-flow` does).
- `pytest tests/`: 34 passed, 6 skipped (openadapt-ml seam tests; they run in CI). Adds 3 regression tests: backend-option forwarding, verbatim web invocation, engine-help rendering.
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)