### PR TITLE
docs: reconcile README substrate maturity to the canonical status manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,23 @@ blanket production-readiness claim.
 the standalone `openadapt-flow <verb>` command behaves identically to
 `openadapt flow <verb>`.
 
+### Substrate maturity
+
+Package maturity above is separate from how far each execution **surface** is
+qualified. These labels come from one canonical, machine-readable
+[status manifest](https://openadapt.ai/status.json) that the website, docs, and
+this README all reconcile to, so no surface can drift ahead of the evidence.
+
+| Surface | Public label | What it means |
+|---------|--------------|---------------|
+| Browser | **Beta** | Reference record → compile → replay path; runs in CI with no OS permissions and backs the public managed subscription. |
+| Windows / macOS / RDP | **Scoped acceptance — design partners only** | Each passed a real, counted scoped qualification (0 silent incorrect successes, 0 over-halts, 0 model calls) for an exact task and environment. Not arbitrary-application or clean-machine support; design-partner only until a customer runs it in production. |
+| Citrix / VDI | **Research / design-partner qualification** | No validated ICA/HDX integration yet; qualification can only begin inside a design partner's real Citrix/VDI environment. RDP evidence does not transfer. |
+| Hosted Cloud | **Beta / public offer** | Live $500/month managed browser-workflow subscription. Maturity is Beta — not a certification, SLA, or completed paid-customer lifecycle. Non-browser hosted substrates are separately scoped design-partner deployments. |
+
+Current components (see the manifest for the source of truth): launcher
+`openadapt` 1.7.1 · `openadapt-flow` 1.19.0 · desktop 0.6.2.
+
 ### CLI reference
 
 ```


### PR DESCRIPTION
## Why
Part of fixing the top external-review finding that OpenAdapt's maturity claims and versions disagree across surfaces. The launcher README (the PyPI long description) must reconcile to the single source of truth: [`https://openadapt.ai/status.json`](https://openadapt.ai/status.json) (added in openadapt-web#222).

## What
- Adds a **Substrate maturity** table to `README.md` whose labels match the manifest and website exactly:
  - Browser: **Beta**
  - Windows / macOS / RDP: **Scoped acceptance — design partners only**
  - Citrix / VDI: **Research / design-partner qualification**
  - Hosted Cloud: **Beta / public offer**
- States the verified component versions (launcher `1.7.1`, `openadapt-flow` `1.19.0`, desktop `0.6.2`) and reaffirms `openadapt-flow`'s canonical compiler/runtime role.
- **No dependency pins changed** (`openadapt-flow[hosted]>=1.17.0,<2` already resolves 1.19.0); `pyproject` `description` already matches the manifest.

Branch is `docs-readme-status` (not `docs/readme-status`) because an existing `docs` branch blocks the `docs/` prefix; this matches the repo convention (`docs-readme-refresh`).

## Verification
- `uv run pytest tests/ -q` → **34 passed, 6 skipped** (Beta lifecycle metadata tests still green).