### PR TITLE
docs(readme): fix Resolution ladder text overflow in masthead SVG

### DIFF
--- a/media/openadapt-hero.svg
+++ b/media/openadapt-hero.svg
@@ -43,9 +43,9 @@
 <rect x="48" y="296" width="250" height="92" rx="13" fill="var(--chip)" stroke="var(--edge)" stroke-width="1.25"/>
 <rect x="49" y="307" width="4" height="70" rx="2" fill="var(--ink3)"/>
 <text x="68" y="326" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="16" font-weight="700" fill="var(--ink)">Resolution ladder</text>
-<text x="68" y="364" font-family="ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace" font-size="10.5" fill="var(--ink2)">structural / template</text>
-<text x="68" y="379" font-family="ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace" font-size="10.5" fill="var(--ink2)">OCR / geometry</text>
-<text x="68" y="394" font-family="ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace" font-size="10.5" fill="var(--ink2)">grounding model optional</text>
+<text x="68" y="346" font-family="ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace" font-size="10.5" fill="var(--ink2)">structural / template</text>
+<text x="68" y="361" font-family="ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace" font-size="10.5" fill="var(--ink2)">OCR / geometry</text>
+<text x="68" y="376" font-family="ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace" font-size="10.5" fill="var(--ink2)">grounding model optional</text>
 <rect x="346" y="296" width="250" height="92" rx="13" fill="var(--chip)" stroke="var(--edge)" stroke-width="1.25"/>
 <rect x="347" y="307" width="4" height="70" rx="2" fill="var(--warn)"/>
 <text x="366" y="326" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="16" font-weight="700" fill="var(--ink)">Armed identity gate</text>


### PR DESCRIPTION
Follow-up to #1041. The "Resolution ladder" box in `media/openadapt-hero.svg` had a larger gap between its heading and its body text than the sibling boxes, and the third line overflowed the box.

**Cause:** the ladder box is the only box with multi-line body text, and those lines started at `y+68` instead of the `y+50` baseline every sibling box's subtitle uses. That gave a 38px heading-to-body gap (vs 20px elsewhere) and placed the third line at `y=394`, past the box bottom at `y=388`.

**Fix:** start the ladder body lines at `y+50` like the other boxes. The three lines now sit at `y=346 / 361 / 376`, matching the sibling heading-to-body gap and fitting inside the 92px box with the same internal padding. The diff is exactly those three text baselines; nothing else changes.

**Checked while in there:** the ladder is the only multi-line box; all other boxes already use the consistent `y+30` title / `y+50` subtitle spacing, and every box's body text sits within its bounds at the rendered size (verified in both light and dark re-renders).

Re-rendered light + dark for review. README/SVG only, no em dashes.