### PR TITLE
docs(readme): use the real OpenAdapt brand mark in the masthead

### DIFF
--- a/media/openadapt-hero.svg
+++ b/media/openadapt-hero.svg
@@ -12,12 +12,7 @@
 <rect x="8" y="8" width="1224" height="632" rx="22" fill="var(--bg)" stroke="var(--edge)" stroke-width="1.25"/>
 <rect x="8" y="8" width="1224" height="5" rx="2.5" fill="var(--accent)"/>
 <rect x="48" y="42" width="54" height="54" rx="15" fill="var(--accent)"/>
-<circle cx="64" cy="69" r="6.5" fill="var(--bg)"/>
-<path d="M73,69 L82,69" stroke="var(--bg)" stroke-width="2.4" stroke-linecap="round"/>
-<path d="M79,65.5 L83,69 L79,72.5" fill="none" stroke="var(--bg)" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
-<rect x="87.0" y="64.0" width="2.6" height="10" rx="1.3" fill="var(--bg)"/>
-<rect x="91.5" y="60.0" width="2.6" height="18" rx="1.3" fill="var(--bg)"/>
-<rect x="96.0" y="62.0" width="2.6" height="14" rx="1.3" fill="var(--bg)"/>
+<path transform="translate(58.84,52.84) scale(2.02)" fill-rule="evenodd" clip-rule="evenodd" d="M8.48024 4H12.4802L12.9802 4.5V6.53H13.5002L14.0002 7.03V8L13.5002 8.5H12.9802V11.5L12.4802 12H9.36024L6.86024 14.76L6.00024 14.4V12H3.50024L3.00024 11.36V8.5H2.50024L2.00024 8V7.03L2.50024 6.53H3.00024V4.36L3.53024 4H7.53024V2.86C7.37351 2.7766 7.24181 2.65299 7.14867 2.50184C7.05552 2.3507 7.00429 2.17749 7.00024 2C7.00024 1.73478 7.1056 1.48043 7.29314 1.29289C7.48067 1.10536 7.73503 1 8.00024 1C8.26546 1 8.51981 1.10536 8.70735 1.29289C8.89489 1.48043 9.00024 1.73478 9.00024 2C8.99203 2.17133 8.93988 2.33767 8.84882 2.48302C8.75775 2.62838 8.63083 2.74786 8.48024 2.83V4ZM12.0002 8V7.03V5H4.00024V7.03V8V10.86L6.50024 11H7.00024V13.19L8.80024 11.15L9.15024 11H12.0002V8ZM9.88026 8.51C9.50581 8.88537 9.02948 9.14266 8.51026 9.25V9.24C8.07712 9.32287 7.6303 9.29878 7.20858 9.16982C6.78686 9.04086 6.40298 8.81094 6.09026 8.5L5.39026 9.21C5.73086 9.54934 6.13531 9.81784 6.58026 10C7.03031 10.1878 7.5126 10.2863 8.00026 10.29C8.96702 10.2841 9.89308 9.90004 10.5803 9.22L9.88026 8.51ZM6.49023 6.5H5.49023V7.5H6.49023V6.5ZM9.49023 6.5H10.4902V7.5H9.49023V6.5Z" fill="var(--bg)"/>
 <text x="120" y="70" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="38" font-weight="800" letter-spacing="-0.5" fill="var(--ink)">OpenAdapt</text>
 <text x="122" y="96" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="16" fill="var(--ink2)">The governed demonstration compiler for GUI workflows</text>
 <rect x="898.4" y="52" width="293.6" height="34" rx="17" fill="var(--accentfill)" stroke="var(--accent)" stroke-width="1.2"/>


### PR DESCRIPTION
Follow-up to #1041 / #1042. The masthead hero (`media/openadapt-hero.svg`) had an improvised logo glyph in the top-left. This swaps it for the **real OpenAdapt mark**.

**Asset used:** the robot-face-in-speech-bubble mark from `openadapt-web` `public/images/favicon.svg` (the site favicon, and the mark rendered in the site header via `AnimatedLogo`). Its 16x16 path is inlined verbatim into the hero SVG, scaled to ~32px and centred inside the existing brand tile. No new logo was invented.

**Details:**
- Mark is knocked out of the green brand tile using the card colour theme variable, so it stays legible in **both light and dark** (light-paper mark on the dark-green tile in light mode; dark mark on the light-green tile in dark mode), and crisp at any size.
- Kept the mark + `OpenAdapt` wordmark lockup, matching the site header.
- The SVG stays a self-contained single file (inline vector path, no external reference), so it still renders standalone on GitHub and PyPI.
- Diff is limited to the logo glyph region; the rest of the diagram is unchanged.

Re-rendered light + dark for review. SVG only, no em dashes.