### PR TITLE
docs: reconcile masthead SVG + substrate maturity to the canonical ladder (scoped -> early access)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://openadapt.ai">
-    <img src="https://raw.githubusercontent.com/OpenAdaptAI/OpenAdapt/main/media/openadapt-hero.svg" width="100%" alt="OpenAdapt is the governed demonstration compiler for GUI workflows. Record a demonstration once, compile it to a deterministic program, and replay it locally with no model calls on the healthy path. When the UI drifts, a resolution ladder (structural, template, OCR, geometry, with an optional grounding model that is never on the hot path) re-resolves the target; armed identity gates and independent out-of-band effect verification guard writes; and the run halts with a report for a human or an AI instead of guessing. It runs across browser (Beta), Windows, macOS and RDP (scoped), Linux (research) and Citrix/VDI (exploratory), surfaced via CLI, desktop app, tray, Cloud (Beta, browser) and emitted MCP servers and Agent Skills.">
+    <img src="https://raw.githubusercontent.com/OpenAdaptAI/OpenAdapt/main/media/openadapt-hero.svg" width="100%" alt="OpenAdapt is the governed demonstration compiler for GUI workflows. Record a demonstration once, compile it to a deterministic program, and replay it locally with no model calls on the healthy path. When the UI drifts, a resolution ladder (structural, template, OCR, geometry, with an optional grounding model that is never on the hot path) re-resolves the target; armed identity gates and independent out-of-band effect verification guard writes; and the run halts with a report for a human or an AI instead of guessing. It runs across browser (Beta), Windows, macOS and RDP (early access), Linux (research) and Citrix/VDI (exploratory), surfaced via CLI, desktop app, tray, Cloud (Beta, browser) and emitted MCP servers and Agent Skills.">
   </a>
 </p>
 
@@ -163,9 +163,10 @@ openadapt flow record --backend rdp --rdp-host 10.0.0.5 --out rec
 ```
 
 The browser path is the Beta reference loop and runs in CI with no OS
-permissions. Windows, macOS, and RDP are scoped, design-partner qualifications
-for specific tasks and environments, not arbitrary-application support, and
-Citrix is research-stage; see [Substrate maturity](#substrate-maturity).
+permissions. Windows, macOS, and RDP are Early access: validated on specific
+named tasks and environments, not arbitrary-application support. Citrix/VDI is
+Exploratory (no validated real-environment integration yet); see
+[Substrate maturity](#substrate-maturity).
 
 Before you deploy, apply the stricter gates:
 
@@ -383,12 +384,20 @@ qualified. These labels come from one canonical, machine-readable
 [status manifest](https://openadapt.ai/status.json) that the website, docs, and
 this README all reconcile to, so no surface can drift ahead of the evidence.
 
+The label is a maturity tier that says how broadly a surface has been exercised
+today, not whether it is first-class in the product:
+
+- **Beta**: works and is broadly exercised.
+- **Early access**: works and is validated on specific named tasks, but not yet broadly exercised.
+- **Exploratory**: no validated real-environment integration yet.
+- **Research**: experimental and not yet part of the governed product.
+
 | Surface | Public label | What it means |
 |---------|--------------|---------------|
 | Browser | **Beta** | Reference record → compile → replay path; runs in CI with no OS permissions and backs the public managed subscription. |
-| Windows / macOS / RDP | **Scoped acceptance — design partners only** | Each passed a real, counted scoped qualification (0 silent incorrect successes, 0 over-halts, 0 model calls) for an exact task and environment. Not arbitrary-application or clean-machine support; design-partner only until a customer runs it in production. |
-| Citrix / VDI | **Research / design-partner qualification** | No validated ICA/HDX integration yet; qualification can only begin inside a design partner's real Citrix/VDI environment. RDP evidence does not transfer. |
-| Hosted Cloud | **Beta / public offer** | Live $500/month managed browser-workflow subscription. Maturity is Beta — not a certification, SLA, or completed paid-customer lifecycle. Non-browser hosted substrates are separately scoped design-partner deployments. |
+| Windows / macOS / RDP | **Early access** | Each passed a real, counted qualification (0 silent incorrect successes, 0 over-halts, 0 model calls) for an exact named task and environment. Not arbitrary-application or clean-machine support; run self-hosted or in a customer-controlled deployment, not in the managed subscription. |
+| Citrix / VDI | **Exploratory** | No validated ICA/HDX integration yet; qualification can only begin inside a design partner's real Citrix/VDI environment. RDP evidence does not transfer. |
+| Hosted Cloud | **Beta** | Live $500/month managed browser-workflow subscription. Maturity is Beta — not a certification, SLA, or completed paid-customer lifecycle. Desktop, RDP, and Citrix run self-hosted or in a customer-controlled deployment, not in the managed subscription. |
 
 Current components (see the manifest for the source of truth): launcher
 `openadapt` 1.7.1 · `openadapt-flow` 1.19.0 · desktop 0.6.2.

--- a/media/openadapt-hero.svg
+++ b/media/openadapt-hero.svg
@@ -77,26 +77,26 @@
 <text x="194.0" y="476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="var(--ink)">Browser</text>
 <rect x="256.6" y="463" width="36.8" height="16" rx="8" fill="var(--accentfill)"/>
 <text x="275.0" y="474.5" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="9.5" font-weight="700" letter-spacing="0.4" text-anchor="middle" fill="var(--accentink)">BETA</text>
-<rect x="319.4" y="456" width="138.8" height="30" rx="8" fill="var(--chip)" stroke="var(--edge)" stroke-width="1.1"/>
+<rect x="319.4" y="456" width="173.0" height="30" rx="8" fill="var(--chip)" stroke="var(--edge)" stroke-width="1.1"/>
 <text x="333.4" y="476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="var(--ink)">Windows</text>
-<rect x="396.0" y="463" width="48.2" height="16" rx="8" fill="var(--warnfill)"/>
-<text x="420.1" y="474.5" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="9.5" font-weight="700" letter-spacing="0.4" text-anchor="middle" fill="var(--warnink)">SCOPED</text>
-<rect x="470.2" y="456" width="123.2" height="30" rx="8" fill="var(--chip)" stroke="var(--edge)" stroke-width="1.1"/>
-<text x="484.2" y="476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="var(--ink)">macOS</text>
-<rect x="531.2" y="463" width="48.2" height="16" rx="8" fill="var(--warnfill)"/>
-<text x="555.3" y="474.5" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="9.5" font-weight="700" letter-spacing="0.4" text-anchor="middle" fill="var(--warnink)">SCOPED</text>
-<rect x="605.4" y="456" width="134.6" height="30" rx="8" fill="var(--chip)" stroke="var(--edge)" stroke-width="1.1"/>
-<text x="619.4" y="476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="var(--ink)">Linux</text>
-<rect x="666.4" y="463" width="59.6" height="16" rx="8" fill="var(--mutefill)"/>
-<text x="696.2" y="474.5" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="9.5" font-weight="700" letter-spacing="0.4" text-anchor="middle" fill="var(--muteink)">RESEARCH</text>
-<rect x="752.0" y="456" width="107.6" height="30" rx="8" fill="var(--chip)" stroke="var(--edge)" stroke-width="1.1"/>
-<text x="766.0" y="476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="var(--ink)">RDP</text>
-<rect x="797.4" y="463" width="48.2" height="16" rx="8" fill="var(--warnfill)"/>
-<text x="821.5" y="474.5" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="9.5" font-weight="700" letter-spacing="0.4" text-anchor="middle" fill="var(--warnink)">SCOPED</text>
-<rect x="871.6" y="456" width="206.3" height="30" rx="8" fill="var(--chip)" stroke="var(--edge)" stroke-width="1.1"/>
-<text x="885.6" y="476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="var(--ink)">Citrix / VDI</text>
-<rect x="987.2" y="463" width="76.7" height="16" rx="8" fill="var(--mutefill)"/>
-<text x="1025.5" y="474.5" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="9.5" font-weight="700" letter-spacing="0.4" text-anchor="middle" fill="var(--muteink)">EXPLORATORY</text>
+<rect x="396.0" y="463" width="82.4" height="16" rx="8" fill="var(--warnfill)"/>
+<text x="437.2" y="474.5" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="9.5" font-weight="700" letter-spacing="0.4" text-anchor="middle" fill="var(--warnink)">EARLY ACCESS</text>
+<rect x="504.4" y="456" width="157.4" height="30" rx="8" fill="var(--chip)" stroke="var(--edge)" stroke-width="1.1"/>
+<text x="518.4" y="476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="var(--ink)">macOS</text>
+<rect x="565.4" y="463" width="82.4" height="16" rx="8" fill="var(--warnfill)"/>
+<text x="606.6" y="474.5" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="9.5" font-weight="700" letter-spacing="0.4" text-anchor="middle" fill="var(--warnink)">EARLY ACCESS</text>
+<rect x="673.8" y="456" width="134.6" height="30" rx="8" fill="var(--chip)" stroke="var(--edge)" stroke-width="1.1"/>
+<text x="687.8" y="476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="var(--ink)">Linux</text>
+<rect x="734.8" y="463" width="59.6" height="16" rx="8" fill="var(--mutefill)"/>
+<text x="764.6" y="474.5" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="9.5" font-weight="700" letter-spacing="0.4" text-anchor="middle" fill="var(--muteink)">RESEARCH</text>
+<rect x="820.4" y="456" width="141.8" height="30" rx="8" fill="var(--chip)" stroke="var(--edge)" stroke-width="1.1"/>
+<text x="834.4" y="476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="var(--ink)">RDP</text>
+<rect x="865.8" y="463" width="82.4" height="16" rx="8" fill="var(--warnfill)"/>
+<text x="907.0" y="474.5" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="9.5" font-weight="700" letter-spacing="0.4" text-anchor="middle" fill="var(--warnink)">EARLY ACCESS</text>
+<rect x="974.2" y="456" width="206.3" height="30" rx="8" fill="var(--chip)" stroke="var(--edge)" stroke-width="1.1"/>
+<text x="988.2" y="476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="var(--ink)">Citrix / VDI</text>
+<rect x="1089.8" y="463" width="76.7" height="16" rx="8" fill="var(--mutefill)"/>
+<text x="1128.1" y="474.5" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="9.5" font-weight="700" letter-spacing="0.4" text-anchor="middle" fill="var(--muteink)">EXPLORATORY</text>
 <text x="48" y="534" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="11" font-weight="700" letter-spacing="1.4" fill="var(--ink3)">SURFACED VIA</text>
 <rect x="180.0" y="520" width="51.4" height="30" rx="8" fill="var(--chip)" stroke="var(--edge)" stroke-width="1.1"/>
 <text x="194.0" y="540" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="var(--ink)">CLI</text>


### PR DESCRIPTION
## Why

The founder asked: *"macOS/Windows/RDP say 'scoped' - what does this mean? why not beta? don't these work?"* They do work. "Scoped" was an unclear label, and the same maturity was written three different ways across surfaces (`status.json`, docs, and this masthead). This aligns the `openadapt` repo to the **single canonical ladder** defined in `public/status.json` on openadapt.ai.

## Canonical ladder

- **Beta** — works and is broadly exercised (Browser, Cloud browser).
- **Early access** — works, validated on specific named tasks, not yet broadly exercised (**Windows / macOS / RDP**, was "scoped").
- **Exploratory** — no validated real-environment integration yet (**Citrix / VDI**, was "Research").
- **Research** — experimental (Linux).

## Changes

- **`media/openadapt-hero.svg`** — the three `SCOPED` bands become `EARLY ACCESS`. Because the badge pills are fixed-geometry chips, the entire "RUNS ACROSS" row is re-laid out (chip widths, badge rects, badge text centers, and all downstream x-positions recomputed; every inter-chip gap stays 12.0px and the row ends at 1180.5, inside the 1240 canvas). Verified by rendering in Chrome (CSS `var()` colors resolve there; `librsvg` does not):

  `Browser [BETA]  Windows [EARLY ACCESS]  macOS [EARLY ACCESS]  Linux [RESEARCH]  RDP [EARLY ACCESS]  Citrix / VDI [EXPLORATORY]`

- **`README.md`** — substrate-maturity table: Windows / macOS / RDP -> **Early access**; Citrix / VDI -> **Exploratory** (its note already said "No validated ICA/HDX integration yet"). Added a tier legend. Alt text and inline prose use the same vocabulary.

Companion PR openadapt-web#259 defines the canonical `status.json` ladder + fixes the hosted-scope overclaim. openadapt-ops docs divergence is flagged separately.