### PR TITLE
docs: fix README safety wording wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ boundary only through explicit sanitization and exact-byte approval. Review the
 The local launcher, compiler/runtime, Desktop application, substrate adapters,
 verification interfaces, and basic qualification tools are MIT licensed.
 OpenAdapt Cloud is the commercial multi-tenant control plane for managed
-operation, fleet governance, billing, and enterprise integrations. Safety-
-critical local verification is not paywalled.
+operation, fleet governance, billing, and enterprise integrations. Local
+safety-critical verification is not paywalled.
 
 ## Evidence
 


### PR DESCRIPTION
## Summary

Fix one Markdown line-wrap artifact in the newly rendered flagship README:
`Safety-\ncritical` rendered as “Safety- critical” on GitHub.

The replacement sentence keeps the same product meaning and renders as:

> Local safety-critical verification is not paywalled.

## Validation

- diff is one sentence only
- `git diff --check`
- rendered through GitHub's Markdown API with no `Safety- critical` text
- exact post-merge main checks for #1047 were already green before this fix:
  CodeQL `30137862118`, secret scan `30137862111`, release/no-op
  `30137862152`, docs notification `30137862109`, and Pages `30137861681`
