### PR TITLE
fix(ci): restore verified docs dispatch action

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -6,7 +6,10 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: peter-evans/repository-dispatch@v4
+      # v4 currently sends a mismatched Content-Length for this payload on
+      # GitHub-hosted runners. Keep the last verified release until upstream
+      # resolves the regression.
+      - uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.DOCS_DISPATCH_TOKEN }}
           repository: OpenAdaptAI/openadapt-maintenance


### PR DESCRIPTION
Fix-forward for post-merge run 30150735551. repository-dispatch v4 emitted an invalid Content-Length for the existing payload; restore v3, which is the last verified action version, without changing token scope, repository, event type, or payload. Exit condition for trying v4 again: an upstream fix and a green push-triggered docs notification run.