### PR TITLE
docs: lead the README with the verified-execution product story (compile, replay, verify, halt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,43 @@ defines what can be claimed for a new deployment.
 The pre-1.0 monolith remains available under [`legacy/`](legacy/) for migration
 history. New product and engine development belongs in `openadapt-flow`.
 
+<details>
+<summary><strong>Research and legacy history</strong></summary>
+
+These surfaces are preserved for continuity and are not part of the supported
+product. None of them are required to record, compile, replay, or verify a
+workflow, and the compiler makes no generative-model calls on its healthy path.
+
+**Research packages.** A separate research line studies whether human
+demonstrations can improve the accuracy of general computer-use models. It is a
+different question from compiling one demonstration into a deterministic script.
+
+| Package | Research focus | Repository |
+|---------|----------------|------------|
+| `openadapt-ml` | Training and inference for multimodal GUI-action models | [openadapt-ml](https://github.com/OpenAdaptAI/openadapt-ml) |
+| `openadapt-evals` | Benchmark evaluation for GUI agents | [openadapt-evals](https://github.com/OpenAdaptAI/openadapt-evals) |
+| `openadapt-retrieval` | Multimodal demonstration retrieval | [openadapt-retrieval](https://github.com/OpenAdaptAI/openadapt-retrieval) |
+| `openadapt-grounding` | UI element localization / grounding models | [openadapt-grounding](https://github.com/OpenAdaptAI/openadapt-grounding) |
+
+Install with `pip install "openadapt[ml,evals]"`. See the
+[research thesis](https://github.com/OpenAdaptAI/openadapt-ml/blob/main/docs/research_thesis.md)
+for methodology, results, and limits.
+
+**Development and operations tooling.** `openadapt-wright`, `openadapt-herald`,
+`openadapt-crier`, `openadapt-consilium`, `openadapt-telemetry`, and
+`openadapt-viewer` support development and operations. They are not required by
+the compiler runtime.
+
+**Pre-1.0 monolith.** The historical monolithic codebase (v0.46.0) is frozen
+under [`legacy/`](legacy/) and remains installable with
+`pip install openadapt==0.46.0`. See
+[docs/LEGACY_FREEZE.md](docs/LEGACY_FREEZE.md) for the migration guide. Early
+demonstrations:
+[Twitter](https://twitter.com/abrichr/status/1784307190062342237) and
+[Loom](https://www.loom.com/share/9d77eb7028f34f7f87c6661fb758d1c0).
+
+</details>
+
 ## Contributing and support
 
 Launcher, packaging, and unified-CLI changes belong here. Compiler, runtime,


### PR DESCRIPTION
## HOLD MERGE. PR-only. Founder decides.

## Context / important finding

The task that generated this PR assumed the flagship README still told the legacy
LMM-training story ("Record GUI demonstrations, train ML models... Generative RPA",
Qwen fine-tuning quickstart). **That premise is stale.** On `origin/main` the README
was already rebuilt around the current product story by merged PR **#1047**
("docs: rebuild flagship README", 2026-07-25) + #1048. The false finding came from a
local checkout that was behind `origin/main`.

So the headline overhaul is **already shipped**: the README now leads with
"Automate the UI-only work your APIs can't reach / verified execution layer",
carries the compile -> replay -> verify -> halt loop ("What makes it different"),
a ~5-command MockMed quickstart on the real `openadapt flow ...` path, the
multi-surface qualification model, the OpenEMR (20/20, 0 model calls) + RVU-audit
evidence lines, and links to openadapt-flow, docs, Cloud, and Desktop. None of the
legacy phrases remain. **I did not rewrite any of that** rewriting freshly-merged
founder work would be a regression.

## What this PR actually changes (additive only, +37 lines)

The one task requirement `#1047` did not satisfy: a clearly-labeled section that
**preserves** the ML/training/eval history so nothing is lost. This restores that as
a **collapsed, demoted "Research and legacy history"** block placed after "Project
map" so it does not re-lead with model training:

- Research packages: `openadapt-ml`, `openadapt-evals`, `openadapt-retrieval`,
  `openadapt-grounding` (with research-thesis link)
- Dev/ops tooling: wright / herald / crier / consilium / telemetry / viewer
- Pre-1.0 monolith (`legacy/`, `pip install openadapt==0.46.0`, migration guide)

No em dashes. All referenced paths verified to exist.

**Tension to decide:** #1047 deliberately dropped the in-README research section.
If you prefer it stay out of the README entirely (history lives in git and in each
sub-package repo), close this PR. It is offered because the driving task explicitly
required preserving that history in the flagship README.

## Accuracy check against the actual package

- `openadapt` 1.7.x is a **Beta launcher/meta-package**; base `dependencies` pull
  `openadapt-flow[hosted]`, so `pip install openadapt` yields a working
  `openadapt flow ...` compiler. Confirmed in `pyproject.toml`. README + this PR
  describe exactly that.
- Cross-surface is framed as governed architecture + per-workflow qualification,
  not live unqualified Citrix ICA/HDX parity. Unchanged by this PR.

## Repo metadata (cannot be set from a PR apply these)

**Description** already updated on `origin/main` and accurate keep as-is:
> Compile a demonstrated GUI workflow into a deterministic, locally executable program. Zero model calls on healthy runs; governed repair; halts instead of guessing. Launcher for openadapt-flow: pip install openadapt

**Topics** still legacy-ML-heavy (`transformers`, `large-language-models`,
`large-multimodal-models`, `large-action-model`, `omniparser`,
`generative-process-automation`, `anthropic`, `google-gemini`, `openai`). Proposed
replacement aligned with the verified-execution story:

```
gh repo edit OpenAdaptAI/OpenAdapt \
  --add-topic demonstration-compiler --add-topic deterministic-replay \
  --add-topic effect-verification --add-topic rpa --add-topic ui-automation \
  --add-topic browser-automation --add-topic rdp --add-topic citrix \
  --add-topic healthcare-automation \
  --remove-topic transformers --remove-topic large-language-models \
  --remove-topic large-multimodal-models --remove-topic large-action-model \
  --remove-topic omniparser --remove-topic generative-process-automation \
  --remove-topic anthropic --remove-topic google-gemini --remove-topic openai \
  --remove-topic ai-agents-framework
```
Kept: process-automation, workflow-automation, gui-automation, desktop-automation,
computer-use, computer-use-agents, local-first, python, agents, ai-agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM