### PR TITLE
docs(metadata): align launcher with governed execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,30 @@
 [project]
 name = "openadapt"
 version = "1.10.0"
-description = "Beta launcher for openadapt-flow: compile demonstrated GUI workflows into deterministic, governed local replay"
+description = "OpenAdapt launcher for compiling demonstrated GUI workflows into deterministic, governed execution"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 license = "MIT"
 authors = [
     {name = "Richard Abrich", email = "richard@openadapt.ai"}
 ]
-keywords = ["gui", "automation", "ml", "rpa", "agent", "vlm", "computer-use"]
+keywords = [
+    "gui",
+    "automation",
+    "workflow",
+    "verification",
+    "desktop",
+    "rdp",
+    "citrix",
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 


### PR DESCRIPTION
## What changed

- align the launcher distribution summary with the governed-execution product
- replace generic ML/VLM/agent keywords with workflow, verification, desktop, RDP, and Citrix discovery terms
- remove research and generic AI classifiers from the production launcher metadata

## Why

The current README already presents a coherent flagship entry point and links the canonical engine correctly, but the published package metadata still frames the launcher as ML/VLM/agent research. This keeps the next release's PyPI entry aligned with the actual OpenAdapt product without changing runtime behavior or triggering a release by itself.

## Validation

- 44 focused package, CLI, metadata, and release-lock tests passed; 5 platform-dependent checks skipped
- built wheel and sdist passed `scripts/verify_release_artifacts.py`
- Ruff and `git diff --check` passed
- inspected generated wheel metadata directly
- verified all public README destinations and the product screenshot return HTTP 200

