### PR TITLE
docs: add Execute partner entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ unavoidable and the outcome needs proof.
 [Documentation](https://docs.openadapt.ai) ·
 [Desktop downloads](https://openadapt.ai/download) ·
 [OpenAdapt Cloud](https://app.openadapt.ai) ·
+[OpenAdapt Execute](https://openadapt.ai/execute) ·
 [Qualify a workflow](https://openadapt.ai/qualify)
 
 > **Repository role:** this is the flagship OpenAdapt project, the source of
@@ -173,6 +174,21 @@ verification interfaces, and basic qualification tools are MIT licensed.
 OpenAdapt Cloud is the commercial multi-tenant control plane for managed
 operation, fleet governance, billing, and enterprise integrations. Local
 safety-critical verification is not paywalled.
+
+## OpenAdapt Execute for partners
+
+[OpenAdapt Execute](https://openadapt.ai/execute) is the private partner
+service for software and service providers that need to complete an authorized
+transaction in an application they cannot directly integrate with. The partner
+supplies structured input and business authorization. OpenAdapt runs the exact
+qualified workflow in the customer-controlled environment, verifies the
+declared business effect, and returns an asynchronous receipt with `VERIFIED`
+or a precise non-success outcome.
+
+OpenAdapt Execute starts with one named transaction and one qualified customer
+environment. It is a private pilot service, not a public self-service API. See
+the [OpenAdapt Execute guide](https://docs.openadapt.ai/commercial/oem-brief/)
+for the partner contract and qualification process.
 
 ## Evidence
 

--- a/platform-manifest.json
+++ b/platform-manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_kind": "openadapt-platform-release-manifest",
   "schema_version": "1.0.0",
-  "generated_at": "2026-07-30T16:52:33+00:00",
+  "generated_at": "2026-07-31T13:30:50+00:00",
   "release_channel": "beta",
   "components": {
     "launcher": {
@@ -26,21 +26,21 @@
     },
     "flow": {
       "package": "openadapt-flow",
-      "version": "1.27.0",
+      "version": "1.27.1",
       "source": "pypi",
       "requires_python": "<3.13,>=3.10",
       "artifacts": [
         {
           "type": "bdist_wheel",
-          "filename": "openadapt_flow-1.27.0-py3-none-any.whl",
-          "url": "https://files.pythonhosted.org/packages/42/e5/c08a34a0fc3ab4d05e37e55db11347fa1eb56fb86082de217f2970c35cd0/openadapt_flow-1.27.0-py3-none-any.whl",
-          "sha256": "1de9fd1fb89811e2411946fcc61bfbf08e433b746ff6a4008f3294332abb816b"
+          "filename": "openadapt_flow-1.27.1-py3-none-any.whl",
+          "url": "https://files.pythonhosted.org/packages/45/23/df60e9ad9a5dc82a4db551612de4f9b621bf20956bf5f0a34b6d8ca73953/openadapt_flow-1.27.1-py3-none-any.whl",
+          "sha256": "99d8f3ef014481356f4bcfc65f694ed2fd47a75e2025c5ddfdae4bfab2194094"
         },
         {
           "type": "sdist",
-          "filename": "openadapt_flow-1.27.0.tar.gz",
-          "url": "https://files.pythonhosted.org/packages/8b/28/f29542489f2a45d3c80f28bde06a344e28d090d3e2721c760b2d6ebcba93/openadapt_flow-1.27.0.tar.gz",
-          "sha256": "2c0c1da300659ea6007d194cc07732e7436b06b2a0cbcf0386256f1064ebc107"
+          "filename": "openadapt_flow-1.27.1.tar.gz",
+          "url": "https://files.pythonhosted.org/packages/af/99/709eeada43b5ab00da94a283d5018233c7511abb5ce33bbfd5e4b548c81f/openadapt_flow-1.27.1.tar.gz",
+          "sha256": "aeabf2b11ae6151fe76c02ee783e8368d10ee984465f858f9d37429b17a15468"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- adds one OpenAdapt Execute link to the README navigation
- explains the private partner service without replacing the free local path
- links to the dependent Execute product page and private-pilot guide

## Verification
- `git diff --check`
- README link and local quickstart contract check

## Merge condition
Do not merge until the Execute product page, docs guide, and shared Cloud contract are merged and deployed.