### PR TITLE
fix(ci): repin the docs dispatch action and stop the recurring bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,10 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    ignore:
+      # v4 breaks the docs dispatch with a mismatched Content-Length on
+      # GitHub-hosted runners. Bumping it silently red-mains the docs sync;
+      # this already happened twice (#1049, #1079). Remove once upstream
+      # ships a fixed release.
+      - dependency-name: "peter-evans/repository-dispatch"
+        versions: ["4.x"]

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -11,12 +11,15 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      # v4 currently sends a mismatched Content-Length for this payload on
-      # GitHub-hosted runners. Keep the last verified release until upstream
-      # resolves the regression.
-      - uses: peter-evans/repository-dispatch@v4
+      # Pinned to v3.0.0 by commit. v4 (v4.0.1) sends a mismatched
+      # Content-Length for this payload on GitHub-hosted runners and fails with
+      # "Request body length does not match content-length header". #1053 pinned
+      # this back once already; a Dependabot bump (#1079) reverted it to v4 and
+      # broke the docs dispatch again. The ignore rule in dependabot.yml keeps
+      # that from recurring. Revisit when upstream ships a fixed v4.
+      - uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.DOCS_DISPATCH_TOKEN }}
-          repository: OpenAdaptAI/openadapt-maintenance
+          repository: OpenAdaptAI/openadapt-ops
           event-type: repo-updated
           client-payload: '{"repo": "${{ github.repository }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Problem

`Notify docs` fails on `main`:

```
##[error]Request body length does not match content-length header
```

`peter-evans/repository-dispatch` v4.0.1 sends a mismatched `Content-Length` for this payload on GitHub-hosted runners, so the dispatch that tells `openadapt-ops` to re-sync documentation never arrives.

## Root cause, and why it appeared now

Not new breakage from the merge that surfaced it. #1053 already pinned this action back to v3 on 2026-07-25 for exactly this reason, and left a comment saying so. Dependabot PR #1079 bumped it to v4 again on 2026-08-12 and the comment did not stop it.

The job has been latently broken since that bump. It only runs on a push touching `README.md` or `CHANGELOG.md`, and the first such push afterwards was #1096, so that merge is where it first showed. The last green run was 2026-08-11, immediately before the bump.

## Fix

- pin the action to the v3.0.0 commit `ff45666` instead of the floating `v4` major tag, so a moved tag cannot change behavior
- ignore `4.x` for this action in `.github/dependabot.yml`, so the bump cannot silently reintroduce the regression a third time
- address the dispatch to `OpenAdaptAI/openadapt-ops` directly instead of relying on the rename redirect from `openadapt-maintenance`

Remove the ignore rule once upstream ships a fixed v4.

## Validation

- `actionlint .github/workflows/notify-docs.yml` — passed
- both files parse as YAML
- the dispatch target is confirmed: `OpenAdaptAI/openadapt-maintenance` resolves to `OpenAdaptAI/openadapt-ops`, whose `sync.yml` listens on `repository_dispatch` type `repo-updated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)