### PR TITLE
build(deps): bump both codeql-action pins to v4.37.7 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Why one pull request instead of two

Dependabot split this into #1100 (`analyze`) and #1102 (`init`). `codeql.yml` pins both to the **same** commit, and CodeQL refuses a run where `init` and `analyze` are different versions. So each pull request on its own fails `Analyze (python)`:

```
-  github/codeql-action/init@5595ccaf…    # v4.37.6
-  github/codeql-action/analyze@5595ccaf… # v4.37.6
```

Bumping both in one commit is the only shape that can pass. This replaces #1100 and #1102, which are closed with a pointer here.

This is the same split-CodeQL pattern that was already hit and fixed once in `openadapt-capture`.

## Checks

`actionlint` clean, YAML parses, exactly two lines change and both are the pinned SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)