### PR TITLE
docs: correct OpenEMR evidence row to 19/20 (safe halt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ for the partner contract and qualification process.
 
 | Evidence | Result |
 |---|---|
-| Public OpenEMR reference workflow | 20/20 effect-verified runs, 39.2s median, 0 model calls |
+| Public OpenEMR reference workflow | 19/20 effect-verified runs (run 20 was a safe halt under the corrected saved-row oracle), 39.2s median, 0 model calls |
 | Heart-care RVU audit customer case | Approximately $75,000/year in recovered billables and several hours of monthly audit work saved |
 
 Read the [benchmark method and comparison](https://openadapt.ai/compare) and


### PR DESCRIPTION
benchmark/openemr/results.json oracle_adjudication (2026-07-28) rejected compiled run 20 under the stricter saved-row contract: the note stayed in the unsaved form and the replayer halted safely. The evidence table now states 19/20 with that halt context instead of the weaker-oracle 20/20.