### PR TITLE
fix(ci): use the complete lifecycle action pin

### DIFF
--- a/.github/workflows/quickstart-lifecycle.yml
+++ b/.github/workflows/quickstart-lifecycle.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload lifecycle evidence
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0 # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: launcher-quickstart-ubuntu
           path: |

--- a/tests/test_quickstart_lifecycle.py
+++ b/tests/test_quickstart_lifecycle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import subprocess
 from pathlib import Path
 
@@ -95,3 +96,11 @@ def test_workflow_runs_the_public_command_in_one_bounded_weekly_job():
     run = next(step["run"] for step in steps if step.get("name", "").startswith("Run"))
     assert "scripts/quickstart_lifecycle.py" in run
     assert "--browser-with-deps" in run
+
+
+def test_workflow_pins_actions_to_full_commit_shas():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    action_refs = re.findall(r"(?m)^\s*uses:\s+\S+@([^\s#]+)", workflow)
+
+    assert action_refs
+    assert all(re.fullmatch(r"[0-9a-f]{40}", ref) for ref in action_refs)


### PR DESCRIPTION
## Summary

- complete the upload-artifact commit SHA in the weekly launcher lifecycle workflow
- add a test that requires every action reference in that workflow to use a full 40-character SHA

## Verification

- actionlint passed
- Ruff passed
- 184 tests passed and 6 skipped