### PR TITLE
docs: lead with the verified base-package quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,22 +36,24 @@ state, the run stops for review.
 
 ## Try it locally
 
-OpenAdapt requires Python 3.10–3.12. Easiest install (creates its own
-environment):
-
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-curl -fsSL https://raw.githubusercontent.com/OpenAdaptAI/openadapt-flow/main/scripts/install.sh | sh
-```
-
-Manual path with pip:
+OpenAdapt requires Python 3.10–3.12. Install the complete local quickstart:
 
 ```bash
 python -m pip install --upgrade openadapt
+openadapt quickstart
 ```
 
-Run the complete bundled tutorial with one command. It needs no account,
-target application, API key, or operating-system automation permissions:
+The base package includes the browser driver for the tutorial. It downloads its
+matching Chromium build only when the first browser action starts. You do not
+need an account, an API key, or a second package extra.
+
+For an isolated command-line installation, use the public installer:
+
+```bash
+curl -fsSL https://openadapt.ai/install.sh | sh
+```
+
+Then run the complete bundled tutorial with one command:
 
 ```bash
 openadapt quickstart


### PR DESCRIPTION
Summary: Make the published README lead with the base package and the effect-verified quickstart. Explain that the base package includes the tutorial browser driver and that Chromium downloads only on first browser use. Keep the isolated public installer as the alternative. Verification: uv run pytest -q (184 passed, 6 skipped); git diff --check.