### PR TITLE
Replace the legacy GitBook link

### DIFF
--- a/legacy/README.md
+++ b/legacy/README.md
@@ -345,7 +345,7 @@ You can assume that you have access to the following functions:
 - `get_events(recording)`: Returns a list of `ActionEvent` objects for the given
   recording.
 
-See [GitBook Documentation](https://openadapt.gitbook.io/openadapt.ai/) for more.
+See the [current OpenAdapt documentation](https://docs.openadapt.ai/) for more.
 
 ### Instructions
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation.

## Summary

The legacy README still sends readers to the deleted GitBook site. This one-line change points the link to the current OpenAdapt documentation, so it doesn't leave readers at the retired host.

## Checklist

- [x] I have tested this change locally
- [x] Documentation is updated if needed
- [ ] CI passes

## Notes

I confirmed that `https://docs.openadapt.ai/` returns HTTP 200 and ran `git diff --check`.
