### PR TITLE
chore: ignore every .env variant, not one at a time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,10 @@ deploy/.env
 # Never-publish workspace material (strategy, prospect research, counsel packs,
 # personal contact details). Created ad hoc; must never reach a remote.
 .private/
+
+# Cover every .env variant, not one at a time. A .env.bak holding live
+# API keys sat in a stash for six weeks and was one `git add -A` from being
+# committed; .env.backup had already been added by hand after an earlier
+# near-miss. Negate the committed template so it stays tracked.
+.env.*
+!.env.example


### PR DESCRIPTION
`.gitignore` covered `.env` and `.env.backup` but not `.env.bak`, `.env.local`, or `.env.old`.

This surfaced concretely: a `.env.bak` containing populated OpenAI, Anthropic, and Google keys has sat in a local stash in `OpenAdapt` since 2026-07-13. It is untracked, on no remote, and absent from disk, so nothing leaked. But it was one `git add -A` from being committed, and the existing `.env.backup` line shows this was already patched by hand once before after a similar near-miss.

Replaces the one-at-a-time approach with `.env.*` and negates `.env.example` so the committed template stays tracked. Verified in each repo: `.env.bak` is now ignored and `.env.example` is not.

Applied to all six repos that had the same gap.