### PR TITLE
chore(policy): sync generated source boundary

### DIFF
--- a/source-policy.public.json
+++ b/source-policy.public.json
@@ -70,8 +70,8 @@
     }
   },
   "generated_from": "OpenAdaptAI/openadapt-internal:source-policy.yaml",
-  "policy_digest": "sha256:09e5092a6f84cbad0b588a9aec65cc7d26492dced2ddce26ca288a3ff81992c9",
-  "policy_last_updated": "2026-07-28",
+  "policy_digest": "sha256:d626f2ad18d2111c1b0cc0f715b1aa8b3a9d73dbb4723a2b2776cce0a9d47199",
+  "policy_last_updated": "2026-08-27",
   "policy_version": 1,
   "public_repositories": {
     ".github": {


### PR DESCRIPTION
Syncs source-policy.public.json with its canonical generated source. The renderer changed only the public policy date and digest. It didn't expose private repository names or policy prose.\n\nLocal checks:\n\n- source-boundary guard passed\n- exact byte match to the canonical render\n- git diff --check passed\n- 66 source-boundary tests passed\n\nRendered file SHA-256: b03b1f9bb0d3b4631c84db1c7e1dd7f26f1cd04e9b4d4d18f6cab2776eed7eb6.