### PR TITLE
docs: record that the CLA is published, not under consideration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,24 @@ that you wrote the contribution or otherwise have the right to submit it
 under the MIT License. Signing off your commits (`git commit -s`) is
 appreciated but the certification applies to every contribution regardless.
 
-A Contributor License Agreement (CLA) is under consideration but has not
-been adopted; today the DCO plus the MIT License govern contributions.
+## Contributor License Agreement
+
+A Contributor License Agreement is published:
+[`openadapt-flow/CLA.md`](https://github.com/OpenAdaptAI/openadapt-flow/blob/main/CLA.md)
+for individuals, and
+[`openadapt-flow/CCLA.md`](https://github.com/OpenAdaptAI/openadapt-flow/blob/main/CCLA.md)
+for companies whose employees contribute on company time. It gives MLDSAI Inc.
+an explicit copyright and patent license, which the MIT License alone doesn't
+provide, and it keeps the option of relicensing the combined work later.
+
+It is not enforced here yet. You don't agree to it by opening a pull request,
+and nothing is implied. You agree when you sign, either through the automated
+CLA check once that check is turned on for this repository, or by email. Until
+then the DCO and the MIT License are what govern your contribution.
+
+The open-core boundary above is the reason this matters. Your contribution may
+end up in the proprietary products MLDSAI Inc. builds on this code. The MIT
+License already permits that. The CLA says it out loud so nobody is surprised.
 
 ## Questions?
 


### PR DESCRIPTION
## Read this first: a lawyer has to sign off before anyone relies on it

Neither the author of this PR nor its reviewer is a lawyer. The agreement this
change points at is adapted from a standard template, not written from scratch,
but adapting a template is still a legal act. Please route it to counsel before
the CLA check is turned on anywhere.

## Why

This file said a Contributor License Agreement was "under consideration but has
not been adopted". That was the honest description, and it was the only one of
the four public repos that got it right. `openadapt-web` and `openadapt-ops`
were meanwhile telling contributors that opening a pull request agreed them to a
CLA at `openadapt-flow/CLA.md`, a file that didn't exist.

It exists now, in **OpenAdaptAI/openadapt-flow#420**, which carries the full
reasoning: why a CLA on top of the DCO, which template it came from, what was
changed, and who was affected by the phantom claim.

This repo has the real external contribution history of the four: 21 distinct
authors all-time. None of them were subject to the false claim, because this
file never made it.

## What changes here

The "under consideration" paragraph becomes a section describing the state that
now holds:

- The individual and corporate texts are published and linked.
- The CLA isn't enforced here. Opening a pull request doesn't sign it, and
  nothing is implied.
- Assent is by signature: the automated CLA check once it's enabled, or an email
  to hello@openadapt.ai.
- Until then the DCO and the MIT License govern a contribution, unchanged from
  what this file already said.

The DCO section above it is untouched.

**Merge openadapt-flow#420 first.** The links here point at
`openadapt-flow/blob/main/`, and they 404 until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
