### PR TITLE
docs: add get-started and the 15s X proof to the README social line

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ live in [`openadapt-flow`](https://github.com/OpenAdaptAI/openadapt-flow), and
 this repository doesn't reimplement them.
 
 [Documentation](https://docs.openadapt.ai) ·
+[Get started](https://docs.openadapt.ai/get-started/) ·
 [Desktop downloads](https://openadapt.ai/download) ·
 [Website](https://openadapt.ai) ·
+[15s proof](https://x.com/OpenAdaptAI/status/2093535221324935360) ·
 [Discord](https://discord.gg/yF527cQbDG)
 
 ## Run it


### PR DESCRIPTION
The README social line had docs, Desktop, the site, and Discord. It didn't point at the live 15s proof, and it didn't point at the get-started walkthrough.

Adds two links at the top:

- Get started -> https://docs.openadapt.ai/get-started/
- 15s proof -> https://x.com/OpenAdaptAI/status/2093535221324935360

Doesn't invent a follower count. Doesn't change the walkthrough paragraph that's already in the body.

Opened by an agent session, not the founder.
